### PR TITLE
COSI-57: Use cosi-scality-runner for COSI E2E test

### DIFF
--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -11,6 +11,11 @@ on:
         description: 'Run the build with tmate debugging enabled'
         required: false
         default: false
+      debug_delay_duration_minutes:
+        type: number
+        description: 'Duration to delay job completion in minutes'
+        required: false
+        default: 5
 
 jobs:
   e2e-tests-with-kind:
@@ -30,12 +35,17 @@ jobs:
       run: |
         kubectl cluster-info
         kubectl get nodes
-
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+    - name: "Debug: SSH to runner"
+      uses: scality/actions/action-ssh-to-runner@v1
       with:
+        tmate-server-host: ${{ secrets.TMATE_SERVER_HOST }}
+        tmate-server-port: ${{ secrets.TMATE_SERVER_PORT }}
+        tmate-server-rsa-fingerprint: ${{ secrets.TMATE_SERVER_RSA_FINGERPRINT }}
+        tmate-server-ed25519-fingerprint: ${{ secrets.TMATE_SERVER_ED25519_FINGERPRINT }}
         detached: true
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      timeout-minutes: 10
+      continue-on-error: true
 
     - name: Setup COSI Controller, CRDs and Driver
       run: |
@@ -91,6 +101,13 @@ jobs:
         pwd
         chmod +x .github/scripts/e2e_test_bucket_creation.sh
         .github/scripts/e2e_test_bucket_creation.sh
+
+    - name: "Delay completion"
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      uses: scality/actions/action-delay-job-completion@1.11.0
+      with:
+        completion_delay_m: ${{ inputs.debug_delay_duration_minutes }}
+      continue-on-error: true
 
     - name: Cleaup IAM and S3 Services
       run: docker compose --profile iam_s3 down


### PR DESCRIPTION
Main PR: https://github.com/scality/cosi/pull/13
new repository

Purpose: test and debug using scality ssh running

Related PRs:
https://github.com/scality/actions/pull/154
https://github.com/scality/devdocs/pull/667

Slack thread: https://scality.slack.com/archives/CFDJAPQ6S/p1730976697811189?thread_ts=1730909009.537229&cid=CFDJAPQ6S

Original idea: https://github.com/scality/cosi/pull/9#discussion_r1830640664