### PR TITLE
COSI-58-add-dependabot-and-codecov-in-ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "scality/object"
+    commit-message:
+      prefix: "gomod"
+      include: "scope"
+    labels:
+      - "gomod"
+      - "dependencies"
+
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "08:00"
+    reviewers:
+      - "scality/object"
+    commit-message:
+      prefix: "github-actions"
+      include: "scope"
+    labels:
+      - "github-actions"
+      - "dependencies"

--- a/.github/workflows/ci-build-and-unit-tests.yml
+++ b/.github/workflows/ci-build-and-unit-tests.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Run tests
         run: make test
 
+      - name: Upload test coverage to codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: scality/cosi-driver
+
   dev-container-build:
     permissions:
       contents: read


### PR DESCRIPTION
Implementing Dependabot for automatic dependency updates and integrating Codecov to monitor and maintain code coverage percentages.: https://app.codecov.io/github/scality/cosi-driver/