### PR TITLE
COSI-33: Add Helm Charts and Update Release Stage to release helm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,31 @@ jobs:
           tag_name: ${{ inputs.tag }}
           name: Release ${{ inputs.tag }}
           generate_release_notes: true
+
+  package-helm-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.16.2
+
+      - name: Package Helm Chart
+        run: |
+          helm package ./helm/scality-cosi-driver --version ${{ inputs.tag }} --app-version ${{ inputs.tag }}
+      - name: Upload Helm Chart as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: helm-chart
+          path: scality-cosi-driver-${{ inputs.tag }}.tgz
+      - name: Push helm chart to ghcr.io
+        run: helm push scality-cosi-driver-${{ inputs.tag }}.tgz oci://ghcr.io/${{ github.repository }}/helm-charts
+      - name: Pull the helm chart
+        run: helm pull oci://ghcr.io/${{ github.repository }}/helm-charts/scality-cosi-driver --version ${{ inputs.tag }}
+      - name: Show the helm chart
+        run: helm show all oci://ghcr.io/${{ github.repository }}/helm-charts/scality-cosi-driver --version ${{ inputs.tag }}
+      - name: Template the helm chart
+        run: helm template oci://ghcr.io/${{ github.repository }}/helm-charts/scality-cosi-driver --version ${{ inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
       tag:
         description: "Tag to be released (e.g., v1.0.0)"
         required: true
+      all_platforms:
+        description: "Build for all platforms (linux/amd64,linux/arm64) or just linux/amd64"
+        required: false
+        type: boolean
+        default: false
 jobs:
   prod-container-build:
     permissions:
@@ -17,7 +22,7 @@ jobs:
       name: cosi-driver
       namespace: ${{ github.repository_owner }}
       tag: ${{ inputs.tag }}
-      platforms: linux/amd64,linux/arm64
+      platforms: ${{ inputs.all_platforms && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
   create-github-release:
     runs-on: ubuntu-latest

--- a/helm/scality-cosi-driver/Chart.yaml
+++ b/helm/scality-cosi-driver/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: scality-cosi-driver
+description: A Helm chart for deploying the Scality COSI Driver
+version: 0.1.0-beta
+appVersion: "1.0"

--- a/helm/scality-cosi-driver/templates/_helpers.tpl
+++ b/helm/scality-cosi-driver/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "scality-cosi-driver.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+{{- end -}}
+
+{{- define "scality-cosi-driver.name" -}}
+{{- .Chart.Name -}}
+{{- end -}}

--- a/helm/scality-cosi-driver/templates/deployment.yaml
+++ b/helm/scality-cosi-driver/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "scality-cosi-driver.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "scality-cosi-driver.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/part-of: container-object-storage-interface
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "scality-cosi-driver.name" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "scality-cosi-driver.name" . }}
+        app.kubernetes.io/part-of: container-object-storage-interface
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      containers:
+        - name: scality-cosi-driver
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--driver-prefix=cosi"
+            - "--v={{ .Values.logLevels.driver }}"
+          resources:
+            limits:
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+          volumeMounts:
+            - mountPath: /var/lib/cosi
+              name: socket
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+        - name: objectstorage-provisioner-sidecar
+          image: gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v={{ .Values.logLevels.sidecar }}"
+          volumeMounts:
+            - mountPath: /var/lib/cosi
+              name: socket
+      volumes:
+        - name: socket
+          emptyDir: {}

--- a/helm/scality-cosi-driver/templates/rbac.yaml
+++ b/helm/scality-cosi-driver/templates/rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scality-object-storage-provisioner-role
+rules:
+  - apiGroups: ["objectstorage.k8s.io"]
+    resources: ["buckets", "bucketaccesses", "bucketclaims", "bucketaccessclasses"]
+    verbs: ["get", "list", "watch", "update", "create", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: [""]
+    resources: ["secrets", "events"]
+    verbs: ["get", "delete", "update", "create"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scality-object-storage-provisioner-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: scality-object-storage-provisioner-role
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/scality-cosi-driver/templates/serviceaccount.yaml
+++ b/helm/scality-cosi-driver/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Values.namespace }}
+{{- end }}

--- a/helm/scality-cosi-driver/values.yaml
+++ b/helm/scality-cosi-driver/values.yaml
@@ -1,0 +1,40 @@
+image:
+  repository: ghcr.io/scality/cosi
+  tag: latest
+  pullPolicy: IfNotPresent
+
+
+replicaCount: 1
+
+
+logLevels:
+  driver: "5"
+  sidecar: "5"
+
+
+namespace: scality-object-storage
+fullnameOverride: scality-cosi-driver
+
+
+serviceAccount:
+  name: scality-object-storage-provisioner
+  create: true
+
+
+resources:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "250m"
+    memory: "256Mi"
+
+
+env:
+  POD_NAMESPACE:
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+
+
+version: 0.1.0-beta-PW.11


### PR DESCRIPTION
Generated using co-pilot:

This PR introduces Helm chart packaging and updates the release pipeline to support multi-platform builds and Helm chart distribution. Key changes include:

1. Added Helm Charts for COSI Driver

	•	Introduced a Helm chart for the Scality COSI Driver located in the ./helm/scality-cosi-driver directory.
	•	Helm chart is packaged and pushed to GitHub Container Registry (GHCR) as an OCI artifact.

2. Updated Release Pipeline

	•	Modified the release stage to:
	•	Support multi-platform builds (linux/amd64, linux/arm64).
	•	Default to building for linux/amd64 unless the all_platforms input is set to true.
	•	Add a Helm chart packaging step to create and upload the chart to GHCR.

3. New GitHub Actions Jobs

	•	package-helm-chart: This job packages the Helm chart, uploads it as an artifact, and pushes it to GHCR for distribution.
	•	create-github-release: Continues to handle release notes and tagging.

Summary:

	•	Added Helm chart for the Scality COSI Driver.
	•	Updated release pipeline to handle multi-platform builds and Helm chart packaging.
	•	Helm chart is now pushed to GHCR for easy installation and distribution.