### PR TITLE
COSI-63: copy-codecov-yml-from-metadata-migration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,12 +8,12 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1%
+        threshold: 30%
         removed_code_behavior: adjust_base
     patch:
       default:
-        target: 100%
-        threshold: 75%
+        target: 40%
+        threshold: 40%
 
 github_checks:
   annotations: true


### PR DESCRIPTION
Heavily inspired from [Metadata-Migration project](https://github.com/scality/metadata-migration/blob/fa07d8a2c15444476e5313a891386116578476f3/codecov.yml) as we like the style in the PRs
Sample  Report
<img width="741" alt="Screenshot 2024-11-15 at 00 57 03" src="https://github.com/user-attachments/assets/f71c4fa4-3c58-43e4-90b7-ea174b976439">
