### PR TITLE
COSI-71: Add IAM client and associated tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.5
 	github.com/aws/aws-sdk-go-v2/config v1.28.5
+	github.com/aws/aws-sdk-go-v2/service/iam v1.38.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.68.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 h1:VaRN3TlFdd6KxX1x3ILT5ynH6HvK
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.24 h1:JX70yGKLj25+lMC5Yyh8wBtvB01GDilyRuJvXJ4piD0=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.24/go.mod h1:+Ln60j9SUTD0LEwnhEB0Xhg61DHqplBrbZpLgyjoEHg=
+github.com/aws/aws-sdk-go-v2/service/iam v1.38.1 h1:hfkzDZHBp9jAT4zcd5mtqckpU4E3Ax0LQaEWWk1VgN8=
+github.com/aws/aws-sdk-go-v2/service/iam v1.38.1/go.mod h1:u36ahDtZcQHGmVm/r+0L1sfKX4fzLEMdCqiKRKkUMVM=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1 h1:iXtILhvDxB6kPvEXgsDhGaZCSC6LQET5ZHSdJozeI0Y=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1/go.mod h1:9nu0fVANtYiAePIBh2/pFUSwtJ402hLnp854CNoDOeE=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.4.5 h1:gvZOjQKPxFXy1ft3QnEyXmT+IqneM9QAUWlM3r0mfqw=

--- a/pkg/util/iamclient/iamclient.go
+++ b/pkg/util/iamclient/iamclient.go
@@ -1,0 +1,192 @@
+package iamclient
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/smithy-go/logging"
+	"k8s.io/klog/v2"
+)
+
+type IAMAPI interface {
+	CreateUser(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error)
+	PutUserPolicy(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error)
+	CreateAccessKey(ctx context.Context, input *iam.CreateAccessKeyInput, opts ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error)
+}
+
+const (
+	defaultRegion  = "us-east-1"
+	requestTimeout = 15 * time.Second
+)
+
+type IAMParams struct {
+	AccessKey string
+	SecretKey string
+	Endpoint  string
+	Region    string
+	TLSCert   []byte // Optional field for TLS certificates
+	Debug     bool
+}
+
+type IAMClient struct {
+	IAMService IAMAPI
+}
+
+func InitIAMClient(params IAMParams) (*IAMClient, error) {
+	if params.AccessKey == "" || params.SecretKey == "" {
+		return nil, fmt.Errorf("AWS credentials are missing")
+	}
+
+	var logger logging.Logger
+	if params.Debug {
+		logger = logging.NewStandardLogger(os.Stdout)
+	} else {
+		logger = nil
+	}
+
+	httpClient := &http.Client{
+		Timeout: requestTimeout,
+	}
+
+	// in the case where endpoint is HTTPS but no certificate is provided, skip TLS validation
+	isHTTPSEndpoint := strings.HasPrefix(params.Endpoint, "https://")
+	skipTLSValidation := isHTTPSEndpoint && len(params.TLSCert) == 0
+	if isHTTPSEndpoint {
+		httpClient.Transport = ConfigureTLSTransport(params.TLSCert, skipTLSValidation)
+	}
+
+	region := params.Region
+	if region == "" {
+		region = defaultRegion
+	}
+
+	ctx := context.Background()
+
+	awsCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(region),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(params.AccessKey, params.SecretKey, "")),
+		config.WithHTTPClient(httpClient),
+		config.WithLogger(logger),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	iamClient := iam.NewFromConfig(awsCfg, func(o *iam.Options) {
+		o.BaseEndpoint = &params.Endpoint
+	})
+
+	return &IAMClient{
+		IAMService: iamClient,
+	}, nil
+}
+
+func ConfigureTLSTransport(certData []byte, skipTLSValidation bool) *http.Transport {
+	tlsSettings := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: skipTLSValidation,
+	}
+
+	if len(certData) > 0 {
+		caCertPool := x509.NewCertPool()
+		if ok := caCertPool.AppendCertsFromPEM(certData); !ok {
+			klog.Warning("Failed to append provided cert data to the certificate pool")
+		}
+		tlsSettings.RootCAs = caCertPool
+	}
+
+	return &http.Transport{
+		TLSClientConfig: tlsSettings,
+	}
+}
+
+// CreateUser creates an IAM user with the specified name.
+func (client *IAMClient) CreateUser(ctx context.Context, userName string) error {
+	input := &iam.CreateUserInput{
+		UserName: &userName,
+	}
+
+	_, err := client.IAMService.CreateUser(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to create IAM user %s: %w", userName, err)
+	}
+
+	klog.InfoS("IAM user creation succeeded", "user", userName)
+	return nil
+}
+
+// AttachS3WildcardInlinePolicy attaches an inline policy to an IAM user for a specific bucket.
+func (client *IAMClient) AttachS3WildcardInlinePolicy(ctx context.Context, userName, bucketName string) error {
+	policyName := fmt.Sprintf("%s-bucket-access", bucketName)
+	policyDocument := fmt.Sprintf(`{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Action": "s3:*",
+				"Resource": [
+					"arn:aws:s3:::%s",
+					"arn:aws:s3:::%s/*"
+				]
+			}
+		]
+	}`, bucketName, bucketName)
+
+	input := &iam.PutUserPolicyInput{
+		UserName:       &userName,
+		PolicyName:     &policyName,
+		PolicyDocument: &policyDocument,
+	}
+
+	_, err := client.IAMService.PutUserPolicy(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to attach inline policy to IAM user %s: %w", userName, err)
+	}
+
+	klog.InfoS("Inline policy attachment succeeded", "user", userName, "policyName", policyName)
+	return nil
+}
+
+// CreateAccessKey generates access keys for an IAM user.
+func (client *IAMClient) CreateAccessKey(ctx context.Context, userName string) (*iam.CreateAccessKeyOutput, error) {
+	input := &iam.CreateAccessKeyInput{
+		UserName: &userName,
+	}
+
+	output, err := client.IAMService.CreateAccessKey(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create access key for IAM user %s: %w", userName, err)
+	}
+
+	klog.InfoS("Access key creation succeeded", "user", userName)
+	return output, nil
+}
+
+// CreateBucketAccess is a helper that combines user creation, policy attachment, and access key generation.
+func (client *IAMClient) CreateBucketAccess(ctx context.Context, userName, bucketName string) (*iam.CreateAccessKeyOutput, error) {
+	err := client.CreateUser(ctx, userName)
+	if err != nil {
+		return nil, err
+	}
+
+	err = client.AttachS3WildcardInlinePolicy(ctx, userName, bucketName)
+	if err != nil {
+		return nil, err
+	}
+
+	accessKeyOutput, err := client.CreateAccessKey(ctx, userName)
+	if err != nil {
+		return nil, err
+	}
+
+	return accessKeyOutput, nil
+}

--- a/pkg/util/iamclient/iamclient_test.go
+++ b/pkg/util/iamclient/iamclient_test.go
@@ -1,0 +1,296 @@
+package iamclient_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/scality/cosi-driver/pkg/util/iamclient"
+)
+
+// MockIAMClient implements the IAMAPI interface for testing
+type MockIAMClient struct {
+	CreateUserFunc      func(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error)
+	PutUserPolicyFunc   func(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error)
+	CreateAccessKeyFunc func(ctx context.Context, input *iam.CreateAccessKeyInput, opts ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error)
+}
+
+func (m *MockIAMClient) CreateUser(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error) {
+	if m.CreateUserFunc != nil {
+		return m.CreateUserFunc(ctx, input, opts...)
+	}
+	return &iam.CreateUserOutput{}, nil
+}
+
+func (m *MockIAMClient) PutUserPolicy(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error) {
+	if m.PutUserPolicyFunc != nil {
+		return m.PutUserPolicyFunc(ctx, input, opts...)
+	}
+	return &iam.PutUserPolicyOutput{}, nil
+}
+
+func (m *MockIAMClient) CreateAccessKey(ctx context.Context, input *iam.CreateAccessKeyInput, opts ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error) {
+	if m.CreateAccessKeyFunc != nil {
+		return m.CreateAccessKeyFunc(ctx, input, opts...)
+	}
+	return &iam.CreateAccessKeyOutput{}, nil
+}
+
+func TestIAMClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "IAMClient Test Suite")
+}
+
+var _ = Describe("IAMClient", func() {
+	var params iamclient.IAMParams
+
+	BeforeEach(func() {
+		params = iamclient.IAMParams{
+			AccessKey: "test-access-key",
+			SecretKey: "test-secret-key",
+			Endpoint:  "https://iam.mock.endpoint",
+			Region:    "us-west-2",
+			TLSCert:   nil,
+			Debug:     false,
+		}
+	})
+
+	Describe("IAM Operations", func() {
+		var mockIAM *MockIAMClient
+
+		BeforeEach(func() {
+			mockIAM = &MockIAMClient{}
+		})
+
+		It("should successfully create a user", func(ctx SpecContext) {
+			mockIAM.CreateUserFunc = func(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error) {
+				Expect(input.UserName).To(Equal(aws.String("test-user")))
+				return &iam.CreateUserOutput{}, nil
+			}
+
+			client, _ := iamclient.InitIAMClient(params)
+			client.IAMService = mockIAM
+
+			err := client.CreateUser(ctx, "test-user")
+			Expect(err).To(BeNil())
+		})
+
+		It("should return an error when CreateUser fails", func(ctx SpecContext) {
+			mockIAM.CreateUserFunc = func(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error) {
+				return nil, fmt.Errorf("simulated CreateUser failure")
+			}
+
+			client, _ := iamclient.InitIAMClient(params)
+			client.IAMService = mockIAM
+
+			err := client.CreateUser(ctx, "test-user")
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("failed to create IAM user test-user"))
+			Expect(err.Error()).To(ContainSubstring("simulated CreateUser failure"))
+		})
+
+		It("should attach an inline policy successfully", func(ctx SpecContext) {
+			mockIAM.PutUserPolicyFunc = func(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error) {
+				Expect(input.UserName).To(Equal(aws.String("test-user")))
+				Expect(*input.PolicyDocument).To(ContainSubstring("s3:*"))
+				Expect(*input.PolicyDocument).To(ContainSubstring("arn:aws:s3:::test-bucket"))
+				return &iam.PutUserPolicyOutput{}, nil
+			}
+
+			client, _ := iamclient.InitIAMClient(params)
+			client.IAMService = mockIAM
+
+			err := client.AttachS3WildcardInlinePolicy(ctx, "test-user", "test-bucket")
+			Expect(err).To(BeNil())
+		})
+
+		It("should return an error when PutUserPolicy fails", func(ctx SpecContext) {
+			mockIAM.PutUserPolicyFunc = func(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error) {
+				return nil, fmt.Errorf("simulated PutUserPolicy failure")
+			}
+
+			client, _ := iamclient.InitIAMClient(params)
+			client.IAMService = mockIAM
+
+			err := client.AttachS3WildcardInlinePolicy(ctx, "test-user", "test-bucket")
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("failed to attach inline policy to IAM user test-user"))
+			Expect(err.Error()).To(ContainSubstring("simulated PutUserPolicy failure"))
+		})
+
+		It("should create an access key successfully", func(ctx SpecContext) {
+			mockIAM.CreateAccessKeyFunc = func(ctx context.Context, input *iam.CreateAccessKeyInput, opts ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error) {
+				Expect(input.UserName).To(Equal(aws.String("test-user")))
+				return &iam.CreateAccessKeyOutput{
+					AccessKey: &types.AccessKey{
+						AccessKeyId:     aws.String("test-access-key-id"),
+						SecretAccessKey: aws.String("test-secret-access-key"),
+					},
+				}, nil
+			}
+
+			client, _ := iamclient.InitIAMClient(params)
+			client.IAMService = mockIAM
+
+			output, err := client.CreateAccessKey(ctx, "test-user")
+			Expect(err).To(BeNil())
+			Expect(output.AccessKey.AccessKeyId).To(Equal(aws.String("test-access-key-id")))
+			Expect(output.AccessKey.SecretAccessKey).To(Equal(aws.String("test-secret-access-key")))
+		})
+
+		It("should fail if credentials are missing", func() {
+			params.AccessKey = ""
+			params.SecretKey = ""
+			client, err := iamclient.InitIAMClient(params)
+			Expect(err).NotTo(BeNil())
+			Expect(client).To(BeNil())
+		})
+
+		It("should return an error when CreateAccessKey fails", func(ctx SpecContext) {
+			mockIAM.CreateAccessKeyFunc = func(ctx context.Context, input *iam.CreateAccessKeyInput, opts ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error) {
+				return nil, fmt.Errorf("simulated CreateAccessKey failure")
+			}
+
+			client, _ := iamclient.InitIAMClient(params)
+			client.IAMService = mockIAM
+
+			output, err := client.CreateAccessKey(ctx, "test-user")
+			Expect(err).NotTo(BeNil())
+			Expect(output).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("failed to create access key for IAM user test-user"))
+			Expect(err.Error()).To(ContainSubstring("simulated CreateAccessKey failure"))
+		})
+	})
+
+	Describe("ConfigureTLSTransport", func() {
+		It("should configure TLS when valid certData is provided", func() {
+			certData := []byte("invalid-cert-data")
+			transport := iamclient.ConfigureTLSTransport(certData, false)
+
+			Expect(transport).NotTo(BeNil())
+			Expect(transport.TLSClientConfig).NotTo(BeNil())
+			Expect(transport.TLSClientConfig.InsecureSkipVerify).To(BeFalse())
+			Expect(transport.TLSClientConfig.RootCAs).NotTo(BeNil())
+		})
+
+		It("should log a warning if invalid certData is provided", func() {
+			certData := []byte("invalid-cert-data")
+			transport := iamclient.ConfigureTLSTransport(certData, false)
+
+			Expect(transport).NotTo(BeNil())
+			Expect(transport.TLSClientConfig).NotTo(BeNil())
+			Expect(transport.TLSClientConfig.InsecureSkipVerify).To(BeFalse())
+			Expect(transport.TLSClientConfig.RootCAs).NotTo(BeNil())
+		})
+
+		It("should skip RootCAs configuration when no certData is provided", func() {
+			transport := iamclient.ConfigureTLSTransport(nil, false)
+
+			Expect(transport).NotTo(BeNil())
+			Expect(transport.TLSClientConfig).NotTo(BeNil())
+			Expect(transport.TLSClientConfig.InsecureSkipVerify).To(BeFalse())
+			Expect(transport.TLSClientConfig.RootCAs).To(BeNil())
+		})
+	})
+
+	Describe("CreateBucketAccess", func() {
+		var mockIAM *MockIAMClient
+
+		BeforeEach(func() {
+			mockIAM = &MockIAMClient{}
+		})
+
+		It("should successfully create a user, attach a policy, and generate an access key", func(ctx SpecContext) {
+			mockIAM.CreateUserFunc = func(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error) {
+				Expect(input.UserName).To(Equal(aws.String("test-user")))
+				return &iam.CreateUserOutput{}, nil
+			}
+
+			mockIAM.PutUserPolicyFunc = func(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error) {
+				Expect(input.UserName).To(Equal(aws.String("test-user")))
+				Expect(*input.PolicyDocument).To(ContainSubstring("arn:aws:s3:::test-bucket"))
+				return &iam.PutUserPolicyOutput{}, nil
+			}
+
+			mockIAM.CreateAccessKeyFunc = func(ctx context.Context, input *iam.CreateAccessKeyInput, opts ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error) {
+				Expect(input.UserName).To(Equal(aws.String("test-user")))
+				return &iam.CreateAccessKeyOutput{
+					AccessKey: &types.AccessKey{
+						AccessKeyId:     aws.String("test-access-key-id"),
+						SecretAccessKey: aws.String("test-secret-access-key"),
+					},
+				}, nil
+			}
+
+			client, _ := iamclient.InitIAMClient(params)
+			client.IAMService = mockIAM
+
+			output, err := client.CreateBucketAccess(ctx, "test-user", "test-bucket")
+			Expect(err).To(BeNil())
+			Expect(output).NotTo(BeNil())
+			Expect(output.AccessKey.AccessKeyId).To(Equal(aws.String("test-access-key-id")))
+			Expect(output.AccessKey.SecretAccessKey).To(Equal(aws.String("test-secret-access-key")))
+		})
+
+		It("should return an error if CreateUser fails", func(ctx SpecContext) {
+			mockIAM.CreateUserFunc = func(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error) {
+				return nil, fmt.Errorf("simulated CreateUser failure")
+			}
+
+			client, _ := iamclient.InitIAMClient(params)
+			client.IAMService = mockIAM
+
+			output, err := client.CreateBucketAccess(ctx, "test-user", "test-bucket")
+			Expect(err).NotTo(BeNil())
+			Expect(output).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("simulated CreateUser failure"))
+		})
+
+		It("should return an error if AttachS3WildcardInlinePolicy fails", func(ctx SpecContext) {
+			mockIAM.CreateUserFunc = func(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error) {
+				return &iam.CreateUserOutput{}, nil
+			}
+
+			mockIAM.PutUserPolicyFunc = func(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error) {
+				return nil, fmt.Errorf("simulated AttachS3WildcardInlinePolicy failure")
+			}
+
+			client, _ := iamclient.InitIAMClient(params)
+			client.IAMService = mockIAM
+
+			output, err := client.CreateBucketAccess(ctx, "test-user", "test-bucket")
+			Expect(err).NotTo(BeNil())
+			Expect(output).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("simulated AttachS3WildcardInlinePolicy failure"))
+		})
+
+		It("should return an error if CreateAccessKey fails", func(ctx SpecContext) {
+			mockIAM.CreateUserFunc = func(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error) {
+				return &iam.CreateUserOutput{}, nil
+			}
+
+			mockIAM.PutUserPolicyFunc = func(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error) {
+				return &iam.PutUserPolicyOutput{}, nil
+			}
+
+			mockIAM.CreateAccessKeyFunc = func(ctx context.Context, input *iam.CreateAccessKeyInput, opts ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error) {
+				return nil, fmt.Errorf("simulated CreateAccessKey failure")
+			}
+
+			client, _ := iamclient.InitIAMClient(params)
+			client.IAMService = mockIAM
+
+			output, err := client.CreateBucketAccess(ctx, "test-user", "test-bucket")
+			Expect(err).NotTo(BeNil())
+			Expect(output).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("simulated CreateAccessKey failure"))
+		})
+	})
+
+})

--- a/pkg/util/s3client/s3client_test.go
+++ b/pkg/util/s3client/s3client_test.go
@@ -27,7 +27,7 @@ func (m *MockS3Client) CreateBucket(ctx context.Context, input *s3.CreateBucketI
 
 func TestS3Client(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "S3Client Suite")
+	RunSpecs(t, "S3Client Test Suite")
 }
 
 var _ = Describe("S3Client", func() {


### PR DESCRIPTION
Added a new IAM client with the following functionality. This will be used to provide bucket access to end user.

Support for
- creating users
- attaching inline policies
- generating access keys. Integration with github.com/aws/aws-sdk-go-v2/service/iam. Added iamclient_test.go for unit tests covering all critical operations, including error scenarios.
Changed RunSpecs description for S3Client tests to reflect consistency ("S3Client Suite" -> "S3Client Test Suite").

An IAM user is created and the inline policy is restricted to the bucket specified. An Access Key ID and Secret Access Key are generated for the IAM user.