### PR TITLE
COSI-39: Bucket-access-API

### DIFF
--- a/cosi-examples/bucketaccess.yaml
+++ b/cosi-examples/bucketaccess.yaml
@@ -1,0 +1,9 @@
+kind: BucketAccess
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: my-bucket-access
+spec:
+  bucketClaimName: my-bucket-claim
+  bucketAccessClassName: my-bac
+  credentialsSecretName: object-storage-access-secret
+  protocol: s3

--- a/cosi-examples/bucketaccessclass.yaml
+++ b/cosi-examples/bucketaccessclass.yaml
@@ -1,0 +1,9 @@
+kind: BucketAccessClass
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: my-bac
+driverName: cosi.scality.com
+authenticationType: KEY
+parameters:
+  objectStorageSecretName: s3-secret-for-cosi
+  objectStorageSecretNameSpace: default

--- a/cosi-examples/bucketaccessclass.yaml
+++ b/cosi-examples/bucketaccessclass.yaml
@@ -6,4 +6,4 @@ driverName: cosi.scality.com
 authenticationType: KEY
 parameters:
   objectStorageSecretName: s3-secret-for-cosi
-  objectStorageSecretNameSpace: default
+  objectStorageSecretNamespace: default

--- a/cosi-examples/s3-secret-for-cosi.yaml
+++ b/cosi-examples/s3-secret-for-cosi.yaml
@@ -9,3 +9,4 @@ stringData:
   secretAccessKey: P+PK+uMB9spUc21huaQoOexqdJoV00tSnl+pc7t7  # Plain text secret key
   endpoint: http://localhost:8000  # Plain text endpoint
   region: us-west-1  # Plain text region
+  iamEndpoint: http://localhost:8600 # [Optional] Plain text IAM endpoint, if different from the S3 endpoint

--- a/docs/development/run-cosi-driver-locally.md
+++ b/docs/development/run-cosi-driver-locally.md
@@ -123,13 +123,26 @@ grpcurl -plaintext -proto cosi.proto -import-path ./proto -unix ./cosi.sock cosi
 - DriverCreateBucket gRPC API
 
 ```sh
-grpcurl -plaintext -proto cosi.proto -import-path ./proto -unix ./cosi.sock -d '{
+grpcurl -plaintext -proto cosi.proto -import-path ./proto -unix -d '{
   "name": "example-bucket",
   "parameters": {
     "objectStorageSecretName": "s3-secret-for-cosi",
     "objectStorageSecretNamespace": "default"
   }
-}' cosi.v1alpha1.Provisioner.DriverCreateBucket
+}' ./cosi.sock cosi.v1alpha1.Provisioner.DriverCreateBucket
+```
+
+- DriverGrantBucketAccess gRPC API
+
+```sh
+grpcurl -plaintext -proto cosi.proto -import-path ./proto -unix -d '{
+  "name": "user-name",
+  "bucketId": "example-bucket",
+  "parameters": {
+    "objectStorageSecretName": "s3-secret-for-cosi",
+    "objectStorageSecretNamespace": "default"
+  }
+}' ./cosi.sock cosi.v1alpha1.Provisioner.DriverGrantBucketAccess
 ```
 
 ## Troubleshooting

--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,8 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.6
 	github.com/aws/aws-sdk-go-v2/config v1.28.5
-	github.com/aws/aws-sdk-go-v2/service/iam v1.38.1
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.71.0
+	github.com/aws/aws-sdk-go-v2/service/iam v1.38.2
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.69.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 h1:VaRN3TlFdd6KxX1x3ILT5ynH6HvK
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.25 h1:r67ps7oHCYnflpgDy2LZU0MAQtQbYIOqNNnqGO6xQkE=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.25/go.mod h1:GrGY+Q4fIokYLtjCVB/aFfCVL6hhGUFl8inD18fDalE=
-github.com/aws/aws-sdk-go-v2/service/iam v1.38.1 h1:hfkzDZHBp9jAT4zcd5mtqckpU4E3Ax0LQaEWWk1VgN8=
-github.com/aws/aws-sdk-go-v2/service/iam v1.38.1/go.mod h1:u36ahDtZcQHGmVm/r+0L1sfKX4fzLEMdCqiKRKkUMVM=
+github.com/aws/aws-sdk-go-v2/service/iam v1.38.2 h1:8iFKuRj/FJipy/aDZ2lbq0DYuEHdrxp0qVsdi+ZEwnE=
+github.com/aws/aws-sdk-go-v2/service/iam v1.38.2/go.mod h1:UBe4z0VZnbXGp6xaCW1ulE9pndjfpsnrU206rWZcR0Y=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1 h1:iXtILhvDxB6kPvEXgsDhGaZCSC6LQET5ZHSdJozeI0Y=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1/go.mod h1:9nu0fVANtYiAePIBh2/pFUSwtJ402hLnp854CNoDOeE=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.4.6 h1:HCpPsWqmYQieU7SS6E9HXfdAMSud0pteVXieJmcpIRI=
@@ -26,8 +26,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.6 h1:50+XsN70R
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.6/go.mod h1:WqgLmwY7so32kG01zD8CPTJWVWM+TzJoOVHwTg4aPug=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.6 h1:BbGDtTi0T1DYlmjBiCr/le3wzhA37O8QTC5/Ab8+EXk=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.6/go.mod h1:hLMJt7Q8ePgViKupeymbqI0la+t9/iYFBjxQCFwuAwI=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.71.0 h1:nyuzXooUNJexRT0Oy0UQY6AhOzxPxhtt4DcBIHyCnmw=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.71.0/go.mod h1:sT/iQz8JK3u/5gZkT+Hmr7GzVZehUMkRZpOaAwYXeGY=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.69.0 h1:Q2ax8S21clKOnHhhr933xm3JxdJebql+R7aNo7p7GBQ=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.69.0/go.mod h1:ralv4XawHjEMaHOWnTFushl0WRqim/gQWesAMF6hTow=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.7 h1:rLnYAfXQ3YAccocshIH5mzNNwZBkBo+bP6EhIxak6Hw=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.7/go.mod h1:ZHtuQJ6t9A/+YDuxOLnbryAmITtr8UysSny3qcyvJTc=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.6 h1:JnhTZR3PiYDNKlXy50/pNeix9aGMo6lLpXwJ1mw8MD4=

--- a/pkg/clients/s3/s3_client.go
+++ b/pkg/clients/s3/s3_client.go
@@ -25,7 +25,7 @@ type S3Client struct {
 	S3Service S3API
 }
 
-func InitS3Client(params util.StorageClientParameters) (*S3Client, error) {
+var InitS3Client = func(params util.StorageClientParameters) (*S3Client, error) {
 	var logger logging.Logger
 	if params.Debug {
 		logger = logging.NewStandardLogger(os.Stdout)

--- a/pkg/driver/provisioner_server_impl.go
+++ b/pkg/driver/provisioner_server_impl.go
@@ -177,6 +177,9 @@ func initializeObjectStorageClient(ctx context.Context, clientset kubernetes.Int
 			return nil, nil, status.Error(codes.Internal, "failed to initialize IAM client")
 		}
 		klog.V(3).InfoS("Successfully initialized IAM client", "endpoint", storageClientParameters.Endpoint)
+	default:
+		klog.ErrorS(nil, "Unsupported object storage provider service", "service", service)
+		return nil, nil, status.Error(codes.Internal, "unsupported object storage provider service")
 	}
 	return client, storageClientParameters, nil
 }

--- a/pkg/driver/provisioner_server_impl.go
+++ b/pkg/driver/provisioner_server_impl.go
@@ -22,6 +22,7 @@ import (
 
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
+	iamclient "github.com/scality/cosi-driver/pkg/clients/iam"
 	s3client "github.com/scality/cosi-driver/pkg/clients/s3"
 	"github.com/scality/cosi-driver/pkg/util"
 	"google.golang.org/grpc/codes"
@@ -93,14 +94,21 @@ func (s *ProvisionerServer) DriverCreateBucket(ctx context.Context,
 	req *cosiapi.DriverCreateBucketRequest) (*cosiapi.DriverCreateBucketResponse, error) {
 	bucketName := req.GetName()
 	parameters := req.GetParameters()
+	service := "S3"
 
 	klog.V(3).InfoS("Received DriverCreateBucket request", "bucketName", bucketName)
 	klog.V(5).InfoS("Processing DriverCreateBucket", "bucketName", bucketName, "parameters", parameters)
 
-	s3Client, s3Params, err := InitializeClient(ctx, s.Clientset, parameters)
+	client, s3Params, err := InitializeClient(ctx, s.Clientset, parameters, service)
 	if err != nil {
 		klog.ErrorS(err, "Failed to initialize object storage provider S3 client", "bucketName", bucketName)
 		return nil, status.Error(codes.Internal, "failed to initialize object storage provider S3 client")
+	}
+
+	s3Client, ok := client.(*s3client.S3Client)
+	if !ok {
+		klog.ErrorS(nil, "Unsupported client type for bucket creation", "bucketName", bucketName)
+		return nil, status.Error(codes.InvalidArgument, "unsupported client type for bucket creation")
 	}
 
 	err = s3Client.CreateBucket(ctx, bucketName, *s3Params)
@@ -131,7 +139,7 @@ func (s *ProvisionerServer) DriverCreateBucket(ctx context.Context,
 	}, nil
 }
 
-func initializeObjectStorageClient(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string) (*s3client.S3Client, *util.StorageClientParameters, error) {
+func initializeObjectStorageClient(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error) {
 	klog.V(3).InfoS("Initializing object storage provider clients", "parameters", parameters)
 
 	ospSecretName, namespace, err := FetchSecretInformation(parameters)
@@ -147,19 +155,30 @@ func initializeObjectStorageClient(ctx context.Context, clientset kubernetes.Int
 		return nil, nil, status.Error(codes.Internal, "failed to get object store user secret")
 	}
 
-	s3Params, err := FetchParameters(ospSecret.Data)
+	storageClientParameters, err := FetchParameters(ospSecret.Data)
 	if err != nil {
 		klog.ErrorS(err, "Failed to fetch S3 parameters from secret", "secretName", ospSecretName)
 		return nil, nil, err
 	}
 
-	s3Client, err := s3client.InitS3Client(*s3Params)
-	if err != nil {
-		klog.ErrorS(err, "Failed to create S3 client", "endpoint", s3Params.Endpoint)
-		return nil, nil, status.Error(codes.Internal, "failed to create S3 client")
+	var client interface{}
+	switch service {
+	case "S3":
+		client, err = s3client.InitS3Client(*storageClientParameters)
+		if err != nil {
+			klog.ErrorS(err, "Failed to initialize S3 client", "endpoint", storageClientParameters.Endpoint)
+			return nil, nil, status.Error(codes.Internal, "failed to initialize S3 client")
+		}
+		klog.V(3).InfoS("Successfully initialized S3 client", "endpoint", storageClientParameters.Endpoint)
+	case "IAM":
+		client, err = iamclient.InitIAMClient(*storageClientParameters)
+		if err != nil {
+			klog.ErrorS(err, "Failed to initialize IAM client", "endpoint", storageClientParameters.Endpoint)
+			return nil, nil, status.Error(codes.Internal, "failed to initialize IAM client")
+		}
+		klog.V(3).InfoS("Successfully initialized IAM client", "endpoint", storageClientParameters.Endpoint)
 	}
-	klog.V(3).InfoS("Successfully initialized S3 client", "endpoint", s3Params.Endpoint)
-	return s3Client, s3Params, nil // Returning both the client and the params
+	return client, storageClientParameters, nil
 }
 
 func fetchObjectStorageProviderSecretInfo(parameters map[string]string) (string, string, error) {
@@ -200,6 +219,12 @@ func fetchS3Parameters(secretData map[string][]byte) (*util.StorageClientParamet
 		return nil, err
 	}
 
+	params.IAMEndpoint = params.Endpoint
+	if value, exists := secretData["iamEndpoint"]; exists && len(value) > 0 {
+		params.IAMEndpoint = string(value)
+		klog.V(5).InfoS("IAM endpoint specified", "iamEndpoint", params.IAMEndpoint)
+	}
+
 	return params, nil
 }
 
@@ -226,8 +251,47 @@ func (s *ProvisionerServer) DriverDeleteBucket(ctx context.Context,
 //	non-nil err -           Internal error                                [requeue'd with exponential backoff]
 func (s *ProvisionerServer) DriverGrantBucketAccess(ctx context.Context,
 	req *cosiapi.DriverGrantBucketAccessRequest) (*cosiapi.DriverGrantBucketAccessResponse, error) {
+	bucketName := req.GetBucketId()
+	userName := req.GetName()
+	parameters := req.GetParameters()
 
-	return nil, status.Error(codes.Unimplemented, "DriverCreateBucket: not implemented")
+	klog.V(3).InfoS("Received DriverGrantBucketAccess request", "bucketName", bucketName, "userName", userName)
+	klog.V(4).InfoS("Processing DriverGrantBucketAccess", "parameters", parameters)
+	klog.V(5).InfoS("Request DriverGrantBucketAccess", "req", req)
+
+	client, iamParams, err := InitializeClient(ctx, s.Clientset, parameters, "IAM")
+
+	if err != nil {
+		klog.ErrorS(err, "Failed to initialize object storage provider IAM client", "bucketName", bucketName, "userName", userName)
+		return nil, status.Error(codes.Internal, "failed to initialize object storage provider IAM client")
+	}
+
+	iamClient, ok := client.(*iamclient.IAMClient)
+	if !ok {
+		klog.ErrorS(nil, "Unsupported client type for bucket access", "bucketName", bucketName, "userName", userName)
+		return nil, status.Error(codes.Internal, "failed to initialize object storage provider IAM client")
+	}
+
+	userInfo, err := iamClient.CreateBucketAccess(ctx, userName, bucketName)
+	if err != nil {
+		klog.ErrorS(err, "Failed to create bucket access", "bucketName", bucketName, "userName", userName)
+		return nil, status.Error(codes.Internal, "failed to create bucket access")
+	}
+
+	klog.V(3).InfoS("Successfully created bucket access", "bucketName", bucketName, "userName", userName)
+	return &cosiapi.DriverGrantBucketAccessResponse{
+		AccountId: userName,
+		Credentials: map[string]*cosiapi.CredentialDetails{
+			"s3": {
+				Secrets: map[string]string{
+					"accessKeyID":     *userInfo.AccessKey.AccessKeyId,
+					"accessSecretKey": *userInfo.AccessKey.SecretAccessKey,
+					"endpoint":        iamParams.Endpoint,
+					"region":          iamParams.Region,
+				},
+			},
+		},
+	}, nil
 }
 
 // DriverDeleteBucketAccess is an idempotent method for deleting bucket access

--- a/pkg/driver/provisioner_server_impl_test.go
+++ b/pkg/driver/provisioner_server_impl_test.go
@@ -154,18 +154,6 @@ var _ = Describe("ProvisionerServer Unimplemented Methods", func() {
 		Expect(err.Error()).To(ContainSubstring("DriverCreateBucket: not implemented"))
 	})
 
-	It("DriverGrantBucketAccess should return Unimplemented error", func() {
-		request := &cosiapi.DriverGrantBucketAccessRequest{
-			BucketId: bucketName,
-			Name:     "test-access",
-		}
-		resp, err := provisioner.DriverGrantBucketAccess(ctx, request)
-		Expect(resp).To(BeNil())
-		Expect(err).To(HaveOccurred())
-		Expect(status.Code(err)).To(Equal(codes.Unimplemented))
-		Expect(err.Error()).To(ContainSubstring("DriverCreateBucket: not implemented"))
-	})
-
 	It("DriverRevokeBucketAccess should return Unimplemented error", func() {
 		request := &cosiapi.DriverRevokeBucketAccessRequest{AccountId: accountID}
 		resp, err := provisioner.DriverRevokeBucketAccess(ctx, request)

--- a/pkg/driver/provisioner_server_impl_test.go
+++ b/pkg/driver/provisioner_server_impl_test.go
@@ -339,6 +339,19 @@ var _ = Describe("initializeObjectStorageClient", Ordered, func() {
 		Expect(s3Params.Region).To(Equal("us-west-2"))
 	})
 
+	It("should return InvalidArgument error for unsupported object storage provider service", func() {
+		_, err := clientset.CoreV1().Secrets("test-namespace").Create(ctx, secret, metav1.CreateOptions{})
+		Expect(err).To(BeNil())
+
+		client, params, err := driver.InitializeClient(ctx, clientset, parameters, "UnsupportedService")
+
+		Expect(client).To(BeNil())
+		Expect(params).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(err.Error()).To(ContainSubstring("unsupported object storage provider service"))
+	})
+
 	It("should return error when FetchSecretInformation fails", func() {
 		delete(parameters, "objectStorageSecretName")
 

--- a/pkg/driver/provisioner_server_impl_test.go
+++ b/pkg/driver/provisioner_server_impl_test.go
@@ -3,8 +3,10 @@ package driver_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	. "github.com/onsi/ginkgo/v2"
@@ -12,6 +14,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	s3client "github.com/scality/cosi-driver/pkg/clients/s3"
 	"github.com/scality/cosi-driver/pkg/driver"
 	"github.com/scality/cosi-driver/pkg/util"
@@ -33,7 +37,24 @@ func (m *MockS3Client) CreateBucket(ctx context.Context, input *s3.CreateBucketI
 	return &s3.CreateBucketOutput{}, nil
 }
 
-var _ = Describe("ProvisionerServer DriverCreateBucket", func() {
+type MockIAMClient struct {
+	CreateBucketAccessFunc func(ctx context.Context, userName, bucketName string) (*iam.CreateAccessKeyOutput, error)
+}
+
+// Mock CreateBucketAccess
+func (m *MockIAMClient) CreateBucketAccess(ctx context.Context, userName, bucketName string) (*iam.CreateAccessKeyOutput, error) {
+	if m.CreateBucketAccessFunc != nil {
+		return m.CreateBucketAccessFunc(ctx, userName, bucketName)
+	}
+	return &iam.CreateAccessKeyOutput{
+		AccessKey: &iamtypes.AccessKey{
+			AccessKeyId:     aws.String("mock-access-key-id"),
+			SecretAccessKey: aws.String("mock-secret-access-key"),
+		},
+	}, nil
+}
+
+var _ = Describe("ProvisionerServer DriverCreateBucket", Ordered, func() {
 	var (
 		mockS3                   *MockS3Client
 		provisioner              *driver.ProvisionerServer
@@ -42,7 +63,7 @@ var _ = Describe("ProvisionerServer DriverCreateBucket", func() {
 		bucketName               string
 		s3Params                 util.StorageClientParameters
 		request                  *cosiapi.DriverCreateBucketRequest
-		originalInitializeClient func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string) (*s3client.S3Client, *util.StorageClientParameters, error)
+		originalInitializeClient func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error)
 	)
 
 	BeforeEach(func() {
@@ -62,19 +83,21 @@ var _ = Describe("ProvisionerServer DriverCreateBucket", func() {
 		}
 		request = &cosiapi.DriverCreateBucketRequest{Name: bucketName}
 
-		// Storing the original method to restore it for other test suits
+		// Store the original function to restore it later
 		originalInitializeClient = driver.InitializeClient
+
+		// Mock InitializeClient with the correct signature
+		driver.InitializeClient = func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error) {
+			if service == "S3" {
+				return &s3client.S3Client{S3Service: mockS3}, &s3Params, nil
+			}
+			return nil, nil, fmt.Errorf("unsupported service: %s", service)
+		}
 	})
 
 	AfterEach(func() {
-		// Restore the original InitializeClient function for other test suites
+		// Restore the original InitializeClient function
 		driver.InitializeClient = originalInitializeClient
-	})
-
-	JustBeforeEach(func() {
-		driver.InitializeClient = func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string) (*s3client.S3Client, *util.StorageClientParameters, error) {
-			return &s3client.S3Client{S3Service: mockS3}, &s3Params, nil
-		}
 	})
 
 	It("should successfully create a new bucket", func() {
@@ -123,9 +146,35 @@ var _ = Describe("ProvisionerServer DriverCreateBucket", func() {
 		Expect(status.Code(err)).To(Equal(codes.Internal))
 		Expect(err.Error()).To(ContainSubstring("Failed to create bucket"))
 	})
+
+	It("should return Internal error when InitializeClient fails", func() {
+		// Mock InitializeClient to return an error
+		driver.InitializeClient = func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error) {
+			return nil, nil, fmt.Errorf("mock initialization error")
+		}
+
+		resp, err := provisioner.DriverCreateBucket(ctx, request)
+		Expect(resp).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(err.Error()).To(ContainSubstring("failed to initialize object storage provider S3 client"))
+	})
+
+	It("should return InvalidArgument error when client type is unsupported", func() {
+		// Mock InitializeClient to return an unsupported client type
+		driver.InitializeClient = func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error) {
+			return &struct{}{}, &s3Params, nil // Returning a struct instead of *s3client.S3Client
+		}
+
+		resp, err := provisioner.DriverCreateBucket(ctx, request)
+		Expect(resp).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("unsupported client type for bucket creation"))
+	})
 })
 
-var _ = Describe("ProvisionerServer Unimplemented Methods", func() {
+var _ = Describe("ProvisionerServer Unimplemented Methods", Ordered, func() {
 	var (
 		provisioner *driver.ProvisionerServer
 		ctx         context.Context
@@ -164,7 +213,7 @@ var _ = Describe("ProvisionerServer Unimplemented Methods", func() {
 	})
 })
 
-var _ = Describe("FetchSecretInformation", func() {
+var _ = Describe("FetchSecretInformation", Ordered, func() {
 	var (
 		parameters map[string]string
 		secretName string
@@ -246,7 +295,7 @@ var _ = Describe("FetchSecretInformation", func() {
 	})
 })
 
-var _ = Describe("initializeObjectStorageClient", func() {
+var _ = Describe("initializeObjectStorageClient", Ordered, func() {
 	var (
 		ctx        context.Context
 		clientset  *fake.Clientset
@@ -280,7 +329,7 @@ var _ = Describe("initializeObjectStorageClient", func() {
 		_, err := clientset.CoreV1().Secrets("test-namespace").Create(ctx, secret, metav1.CreateOptions{})
 		Expect(err).To(BeNil())
 
-		s3Client, s3Params, err := driver.InitializeClient(ctx, clientset, parameters)
+		s3Client, s3Params, err := driver.InitializeClient(ctx, clientset, parameters, "S3")
 		Expect(err).To(BeNil())
 		Expect(s3Client).NotTo(BeNil())
 		Expect(s3Params).NotTo(BeNil())
@@ -293,7 +342,7 @@ var _ = Describe("initializeObjectStorageClient", func() {
 	It("should return error when FetchSecretInformation fails", func() {
 		delete(parameters, "objectStorageSecretName")
 
-		s3Client, s3Params, err := driver.InitializeClient(ctx, clientset, parameters)
+		s3Client, s3Params, err := driver.InitializeClient(ctx, clientset, parameters, "S3")
 		Expect(err).To(HaveOccurred())
 		Expect(s3Client).To(BeNil())
 		Expect(s3Params).To(BeNil())
@@ -302,7 +351,7 @@ var _ = Describe("initializeObjectStorageClient", func() {
 	})
 
 	It("should return error when secret is not found", func() {
-		s3Client, s3Params, err := driver.InitializeClient(ctx, clientset, parameters)
+		s3Client, s3Params, err := driver.InitializeClient(ctx, clientset, parameters, "S3")
 		Expect(err).To(HaveOccurred())
 		Expect(s3Client).To(BeNil())
 		Expect(s3Params).To(BeNil())
@@ -315,16 +364,45 @@ var _ = Describe("initializeObjectStorageClient", func() {
 		_, err := clientset.CoreV1().Secrets("test-namespace").Create(ctx, secret, metav1.CreateOptions{})
 		Expect(err).To(BeNil())
 
-		s3Client, s3Params, err := driver.InitializeClient(ctx, clientset, parameters)
+		s3Client, s3Params, err := driver.InitializeClient(ctx, clientset, parameters, "S3")
 		Expect(err).To(HaveOccurred())
 		Expect(s3Client).To(BeNil())
 		Expect(s3Params).To(BeNil())
 		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
 		Expect(err.Error()).To(ContainSubstring("accessKeyID is required"))
 	})
+
+	It("should return error when S3 client initialization fails in initializeObjectStorageClient", func() {
+		// Create a mock secret in the fake clientset
+		secret.Data = map[string][]byte{
+			"accessKeyId":     []byte("test-access-key"),
+			"secretAccessKey": []byte("test-secret-key"),
+			"endpoint":        []byte("https://test-endpoint"),
+			"region":          []byte("us-west-2"),
+		}
+		_, err := clientset.CoreV1().Secrets("test-namespace").Create(ctx, secret, metav1.CreateOptions{})
+		Expect(err).To(BeNil())
+
+		// Store the original InitS3Client function
+		originalInitS3Client := s3client.InitS3Client
+		defer func() { s3client.InitS3Client = originalInitS3Client }()
+
+		// Mock InitS3Client to return an error
+		s3client.InitS3Client = func(params util.StorageClientParameters) (*s3client.S3Client, error) {
+			return nil, fmt.Errorf("mock S3 client initialization error")
+		}
+
+		// Call InitializeClient and check for the expected error
+		client, params, err := driver.InitializeClient(ctx, clientset, parameters, "S3")
+		Expect(client).To(BeNil())
+		Expect(params).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(err.Error()).To(ContainSubstring("failed to initialize S3 client"))
+	})
 })
 
-var _ = Describe("FetchParameters", func() {
+var _ = Describe("FetchParameters", Ordered, func() {
 	var (
 		secretData map[string][]byte
 	)
@@ -335,6 +413,7 @@ var _ = Describe("FetchParameters", func() {
 			"secretAccessKey": []byte("test-secret-key"),
 			"endpoint":        []byte("https://test-endpoint"),
 			"region":          []byte("us-west-2"),
+			"iamEndpoint":     []byte("https://test-iam-endpoint"),
 		}
 	})
 
@@ -382,5 +461,108 @@ var _ = Describe("FetchParameters", func() {
 		Expect(s3Params).To(BeNil())
 		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
 		Expect(err.Error()).To(ContainSubstring("endpoint is required"))
+	})
+
+	It("should have seperate IAM endpoint if specified", func() {
+		s3Params, err := driver.FetchParameters(secretData)
+		Expect(err).To(BeNil())
+		Expect(s3Params).NotTo(BeNil())
+		Expect(s3Params.IAMEndpoint).To(Equal("https://test-iam-endpoint"))
+		Expect(s3Params.IAMEndpoint).NotTo(Equal(s3Params.Endpoint))
+	})
+
+	It("Should have the same IAM endpoint as the endpoint if not specified", func() {
+		delete(secretData, "iamEndpoint")
+		s3Params, err := driver.FetchParameters(secretData)
+		Expect(err).To(BeNil())
+		Expect(s3Params).NotTo(BeNil())
+		Expect(s3Params.IAMEndpoint).To(Equal("https://test-endpoint"))
+		Expect(s3Params.IAMEndpoint).To(Equal(s3Params.Endpoint))
+	})
+})
+
+var _ = Describe("ProvisionerServer DriverGrantBucketAccess", func() {
+	var (
+		mockIAMClient            *MockIAMClient
+		provisioner              *driver.ProvisionerServer
+		ctx                      context.Context
+		clientset                *fake.Clientset
+		originalInitializeClient func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error)
+		bucketName, userName     string
+		parameters               map[string]string
+		request                  *cosiapi.DriverGrantBucketAccessRequest
+		iamParams                *util.StorageClientParameters
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		clientset = fake.NewSimpleClientset()
+		provisioner = &driver.ProvisionerServer{
+			Clientset: clientset,
+		}
+		bucketName = "test-bucket"
+		userName = "test-user"
+		parameters = map[string]string{
+			"key": "value", // Example parameter; adapt as necessary
+		}
+		request = &cosiapi.DriverGrantBucketAccessRequest{
+			BucketId:   bucketName,
+			Name:       userName,
+			Parameters: parameters,
+		}
+		iamParams = &util.StorageClientParameters{
+			Endpoint: "https://test-endpoint",
+			Region:   "us-west-2",
+		}
+
+		// Mock InitializeClient
+		originalInitializeClient = driver.InitializeClient
+		mockIAMClient = &MockIAMClient{}
+		driver.InitializeClient = func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error) {
+			if service == "IAM" {
+				return mockIAMClient, iamParams, nil
+			}
+			return nil, nil, fmt.Errorf("unsupported service: %s", service)
+		}
+	})
+
+	AfterEach(func() {
+		driver.InitializeClient = originalInitializeClient
+	})
+
+	It("should return Internal error when IAM client initialization fails", func() {
+		driver.InitializeClient = func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error) {
+			return nil, nil, fmt.Errorf("mock initialization error")
+		}
+
+		resp, err := provisioner.DriverGrantBucketAccess(ctx, request)
+		Expect(resp).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(err.Error()).To(ContainSubstring("failed to initialize object storage provider IAM client"))
+	})
+
+	It("should return Internal error for unsupported client type", func() {
+		driver.InitializeClient = func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error) {
+			return &struct{}{}, iamParams, nil // Return unsupported type
+		}
+
+		resp, err := provisioner.DriverGrantBucketAccess(ctx, request)
+		Expect(resp).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(err.Error()).To(ContainSubstring("failed to initialize object storage provider IAM client"))
+	})
+
+	It("should return Internal error when CreateBucketAccess fails", func() {
+		mockIAMClient.CreateBucketAccessFunc = func(ctx context.Context, userName, bucketName string) (*iam.CreateAccessKeyOutput, error) {
+			return nil, fmt.Errorf("mock failure")
+		}
+
+		resp, err := provisioner.DriverGrantBucketAccess(ctx, request)
+		Expect(resp).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(err.Error()).To(ContainSubstring("failed to initialize object storage provider IAM client"))
 	})
 })

--- a/pkg/util/storage_client.go
+++ b/pkg/util/storage_client.go
@@ -22,7 +22,8 @@ type StorageClientParameters struct {
 	AccessKeyID     string
 	SecretAccessKey string
 	Endpoint        string
-	Region          string
+	IAMEndpoint     string // Optional field for IAM endpoint(default: Endpoint)
+	Region          string // Optional field for region
 	TLSCert         []byte // Optional field for TLS certificates
 	Debug           bool   // Optional field for debug mode
 }

--- a/pkg/util/storage_client_test.go
+++ b/pkg/util/storage_client_test.go
@@ -18,6 +18,7 @@ var _ = Describe("StorageClientUtilities", func() {
 			Expect(params.AccessKeyID).To(BeEmpty())
 			Expect(params.SecretAccessKey).To(BeEmpty())
 			Expect(params.Endpoint).To(BeEmpty())
+			Expect(params.IAMEndpoint).To(BeEmpty())
 			Expect(params.TLSCert).To(BeNil())
 		})
 	})


### PR DESCRIPTION
Note to reviewers:
- Easier to review commit by commit
- Unit tests are at around 85%, once we have more experience, towards the end(~2weeks) I will create a PR to increase it to 90%. 
- Today the plan has changed per request from eng and product leads. We want to show features to customer and get some feedback. A lot of stuff and structure for the code introduced in this PR will change once we introduce Observability but logic will remain the same.
- In one of the next 3 PRs we will have E2E tests


Below is generated by Copilot:

This pull request introduces several changes to the COSI driver, focusing on adding support for IAM endpoints, improving client initialization, and enhancing testing. The most important changes include updates to YAML configuration files, modifications to IAM client initialization, and enhancements to the `ProvisionerServer` methods.

### Configuration Updates:
* [`cosi-examples/bucketaccess.yaml`](diffhunk://#diff-1b4da705f4a2a15d800fb7e2aa6c6931e01dddde51e4b38f4e138c114736a6c7R1-R9): Added a new `BucketAccess` configuration example.
* [`cosi-examples/bucketaccessclass.yaml`](diffhunk://#diff-ab982d26722c4e39592b2f2e4a2fda17aca4aa1cdbf8b1ca0763d799feed17beR1-R9): Added a new `BucketAccessClass` configuration example.
* [`cosi-examples/s3-secret-for-cosi.yaml`](diffhunk://#diff-c0847282464a426b5450f477788b27df5ee3e77fae87ad3ca5ccc2908ab80b88R12): Added an optional IAM endpoint to the secret configuration.

### IAM Client Enhancements:
* [`pkg/clients/iam/iam_client.go`](diffhunk://#diff-c1e1a2d9ef3c69dbe86a04abe63e8786c7d90c7fca5af6c343706e0b139d32b7R18-R20): Introduced a constant for IAM user inline policy postfix and updated IAM client initialization to use the IAM endpoint. [[1]](diffhunk://#diff-c1e1a2d9ef3c69dbe86a04abe63e8786c7d90c7fca5af6c343706e0b139d32b7R18-R20) [[2]](diffhunk://#diff-c1e1a2d9ef3c69dbe86a04abe63e8786c7d90c7fca5af6c343706e0b139d32b7L40-R43) [[3]](diffhunk://#diff-c1e1a2d9ef3c69dbe86a04abe63e8786c7d90c7fca5af6c343706e0b139d32b7L57-R60) [[4]](diffhunk://#diff-c1e1a2d9ef3c69dbe86a04abe63e8786c7d90c7fca5af6c343706e0b139d32b7L82-R85)
* [`pkg/clients/iam/iam_client_test.go`](diffhunk://#diff-25361ca5245ad7fec6bfd5bc84b8d3c21750328bba1c7d83218d82a4fddf1053R62): Updated tests to include IAM endpoint and validate inline policy names and content. [[1]](diffhunk://#diff-25361ca5245ad7fec6bfd5bc84b8d3c21750328bba1c7d83218d82a4fddf1053R62) [[2]](diffhunk://#diff-25361ca5245ad7fec6bfd5bc84b8d3c21750328bba1c7d83218d82a4fddf1053L99-R114)

### Provisioner Server Improvements:
* [`pkg/driver/provisioner_server_impl.go`](diffhunk://#diff-7e307dcda454c81fe27064b0f77cb8f1e4c6f1ab8ac58b2654f44decdcefe46eR97-R113): Enhanced `DriverCreateBucket` and `DriverGrantBucketAccess` methods to support IAM client initialization and handle different client types. [[1]](diffhunk://#diff-7e307dcda454c81fe27064b0f77cb8f1e4c6f1ab8ac58b2654f44decdcefe46eR97-R113) [[2]](diffhunk://#diff-7e307dcda454c81fe27064b0f77cb8f1e4c6f1ab8ac58b2654f44decdcefe46eL134-R142) [[3]](diffhunk://#diff-7e307dcda454c81fe27064b0f77cb8f1e4c6f1ab8ac58b2654f44decdcefe46eL150-R181) [[4]](diffhunk://#diff-7e307dcda454c81fe27064b0f77cb8f1e4c6f1ab8ac58b2654f44decdcefe46eR222-R227) [[5]](diffhunk://#diff-7e307dcda454c81fe27064b0f77cb8f1e4c6f1ab8ac58b2654f44decdcefe46eR254-R294)
* [`pkg/driver/provisioner_server_impl_test.go`](diffhunk://#diff-9ddab9132959bd887eb3093caef4c1300f279a63691af8fd14147e059e740c48R6-R18): Added mock IAM client and updated tests to handle multiple client types. [[1]](diffhunk://#diff-9ddab9132959bd887eb3093caef4c1300f279a63691af8fd14147e059e740c48R6-R18) [[2]](diffhunk://#diff-9ddab9132959bd887eb3093caef4c1300f279a63691af8fd14147e059e740c48L36-R57) [[3]](diffhunk://#diff-9ddab9132959bd887eb3093caef4c1300f279a63691af8fd14147e059e740c48L45-R66) [[4]](diffhunk://#diff-9ddab9132959bd887eb3093caef4c1300f279a63691af8fd14147e059e740c48L65-R104)

### Dependency Updates:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L20-R21): Updated AWS SDK dependencies to their latest versions. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L20-R21) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L35-R37)

### Documentation Updates:
* [`docs/development/run-cosi-driver-locally.md`](diffhunk://#diff-9578bad5d7f71476b33b778f9fb2b27961ca17c47fa961a9aa649a964d5c6c02L126-R145): Added documentation for the `DriverGrantBucketAccess` gRPC API.