### PR TITLE
COSI-40, COSI-52: Revoke Bucket Access API Implementation and Tests

### DIFF
--- a/.github/scripts/cleanup_cosi_resources.sh
+++ b/.github/scripts/cleanup_cosi_resources.sh
@@ -51,8 +51,7 @@ for BUCKET_NAME in $BUCKET_NAMES; do
   log_and_run kubectl patch bucket "$BUCKET_NAME" -p '{"metadata":{"finalizers":[]}}' --type=merge || { echo "Finalizers not found for bucket: $BUCKET_NAME" | tee -a "$LOG_FILE"; }
 done
 
-log_and_run echo "Deleting Bucket Access and Bucket Access Class..."
-log_and_run kubectl delete -f cosi-examples/bucketaccess.yaml || { echo "No BucketAccess resources found." | tee -a "$LOG_FILE"; }
+log_and_run echo "Deleting Bucket Access Class..."
 log_and_run kubectl delete -f cosi-examples/bucketaccessclass.yaml --all || { echo "No BucketAccessClass resources found." | tee -a "$LOG_FILE"; }
 
 log_and_run echo "Deleting Bucket Class and Bucket Claim..."

--- a/.github/scripts/e2e_tests.sh
+++ b/.github/scripts/e2e_tests.sh
@@ -212,4 +212,31 @@ if [[ "$ACTUAL_PROTOCOLS" != "$EXPECTED_PROTOCOLS" ]]; then
   exit 1
 fi
 
+# Step 11: Delete Bucket Access Resource
+log_and_run echo "Deleting Bucket Access Resource..."
+log_and_run kubectl delete -f cosi-examples/bucketaccess.yaml
+
+# Step 12: Verify IAM User Deletion
+log_and_run echo "Verifying IAM user '$IAM_USER_NAME' deletion..."
+log_and_run aws --endpoint-url "$IAM_ENDPOINT" iam get-user --user-name "$IAM_USER_NAME"
+
+# Retry logic for checking user deletion
+
+for ((i=1; i<=$ATTEMPTS; i++)); do
+  USER_EXISTS="$(aws --endpoint-url "$IAM_ENDPOINT" iam get-user --user-name "$IAM_USER_NAME" 2>&1 || true)"
+
+  if [[ "$USER_EXISTS" == *"NoSuchEntity"* ]]; then
+    log_and_run echo "IAM user '$IAM_USER_NAME' successfully deleted."
+    break
+  else
+    log_and_run echo "Attempt $i: IAM user '$IAM_USER_NAME' still exists. Retrying in $DELETE_DELAY seconds..."
+    sleep $DELAY
+  fi
+done
+
+if [[ "$USER_EXISTS" != *"NoSuchEntity"* ]]; then
+  log_and_run echo "IAM user '$IAM_USER_NAME' was not deleted."
+  exit 1
+fi
+
 log_and_run echo "All verifications for object-storage-access-secret passed successfully."

--- a/.github/scripts/e2e_tests.sh
+++ b/.github/scripts/e2e_tests.sh
@@ -136,7 +136,7 @@ log_and_run echo "IAM user found: $IAM_USER_NAME"
 
 log_and_run echo "Verifying inline policy attached to IAM user..."
 INLINE_POLICY="$(aws --endpoint-url "$IAM_ENDPOINT" iam list-user-policies --user-name "$IAM_USER_NAME" --query "PolicyNames[0]" --output text)"
-EXPECTED_INLINE_POLICY="$BUCKET_FOUND-cosi-ba"
+EXPECTED_INLINE_POLICY="$BUCKET_FOUND"
 
 if [[ "$INLINE_POLICY" != "$EXPECTED_INLINE_POLICY" ]]; then
   log_and_run echo "Inline policy '$INLINE_POLICY' does not match expected bucket name '$EXPECTED_INLINE_POLICY'."

--- a/pkg/clients/iam/iam_client.go
+++ b/pkg/clients/iam/iam_client.go
@@ -16,8 +16,6 @@ import (
 )
 
 // postfix for inline policy which is created when COSI receives a BucketAccess (BA) request
-const IAMUserInlinePolicyPostfix = "-cosi-ba"
-
 type IAMAPI interface {
 	CreateUser(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error)
 	PutUserPolicy(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error)
@@ -84,7 +82,6 @@ func (client *IAMClient) CreateUser(ctx context.Context, userName string) error 
 
 // AttachS3WildcardInlinePolicy attaches an inline policy to an IAM user for a specific bucket.
 func (client *IAMClient) AttachS3WildcardInlinePolicy(ctx context.Context, userName, bucketName string) error {
-	policyName := fmt.Sprintf("%s%s", bucketName, IAMUserInlinePolicyPostfix)
 	policyDocument := fmt.Sprintf(`{
 		"Version": "2012-10-17",
 		"Statement": [
@@ -101,7 +98,7 @@ func (client *IAMClient) AttachS3WildcardInlinePolicy(ctx context.Context, userN
 
 	input := &iam.PutUserPolicyInput{
 		UserName:       &userName,
-		PolicyName:     &policyName,
+		PolicyName:     &bucketName,
 		PolicyDocument: &policyDocument,
 	}
 
@@ -110,7 +107,7 @@ func (client *IAMClient) AttachS3WildcardInlinePolicy(ctx context.Context, userN
 		return fmt.Errorf("failed to attach inline policy to IAM user %s: %w", userName, err)
 	}
 
-	klog.InfoS("Inline policy attachment succeeded", "user", userName, "policyName", policyName)
+	klog.InfoS("Inline policy attachment succeeded", "user", userName, "policyName", bucketName)
 	return nil
 }
 

--- a/pkg/clients/iam/iam_client_test.go
+++ b/pkg/clients/iam/iam_client_test.go
@@ -74,7 +74,7 @@ var _ = Describe("IAMClient", func() {
 		It("should attach an inline policy with the correct name and content", func(ctx SpecContext) {
 			bucketName := "inline-policy-bucket-test"
 			mockIAM.PutUserPolicyFunc = func(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error) {
-				expectedPolicyName := bucketName + iamclient.IAMUserInlinePolicyPostfix
+				expectedPolicyName := bucketName
 				Expect(input.UserName).To(Equal(aws.String("test-user")))
 				Expect(*input.PolicyName).To(Equal(expectedPolicyName))
 				Expect(*input.PolicyDocument).To(ContainSubstring("s3:*"))

--- a/pkg/driver/provisioner_server_impl_test.go
+++ b/pkg/driver/provisioner_server_impl_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	bucketv1alpha1 "sigs.k8s.io/container-object-storage-interface-api/apis/objectstorage/v1alpha1"
 	bucketclientset "sigs.k8s.io/container-object-storage-interface-api/client/clientset/versioned"
 	bucketclientfake "sigs.k8s.io/container-object-storage-interface-api/client/clientset/versioned/fake"
 	cosiapi "sigs.k8s.io/container-object-storage-interface-spec"
@@ -266,15 +267,6 @@ var _ = Describe("ProvisionerServer Unimplemented Methods", Ordered, func() {
 	It("DriverDeleteBucket should return Unimplemented error", func(ctx SpecContext) {
 		request := &cosiapi.DriverDeleteBucketRequest{BucketId: bucketName}
 		resp, err := provisioner.DriverDeleteBucket(ctx, request)
-		Expect(resp).To(BeNil())
-		Expect(err).To(HaveOccurred())
-		Expect(status.Code(err)).To(Equal(codes.Unimplemented))
-		Expect(err.Error()).To(ContainSubstring("DriverCreateBucket: not implemented"))
-	})
-
-	It("DriverRevokeBucketAccess should return Unimplemented error", func(ctx SpecContext) {
-		request := &cosiapi.DriverRevokeBucketAccessRequest{AccountId: accountID}
-		resp, err := provisioner.DriverRevokeBucketAccess(ctx, request)
 		Expect(resp).To(BeNil())
 		Expect(err).To(HaveOccurred())
 		Expect(status.Code(err)).To(Equal(codes.Unimplemented))
@@ -673,5 +665,146 @@ var _ = Describe("ProvisionerServer DriverGrantBucketAccess", Ordered, func() {
 		Expect(err).To(HaveOccurred())
 		Expect(status.Code(err)).To(Equal(codes.Internal))
 		Expect(err.Error()).To(ContainSubstring("failed to create bucket access"))
+	})
+})
+
+var _ = Describe("ProvisionerServer DriverRevokeBucketAccess", Ordered, func() {
+	var (
+		provisioner              *driver.ProvisionerServer
+		mockIAMClient            *mock.MockIAMClient
+		bucketClientset          *bucketclientfake.Clientset
+		clientset                *fake.Clientset
+		bucketName, userName     string
+		request                  *cosiapi.DriverRevokeBucketAccessRequest
+		secretName               string
+		originalInitializeClient func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error)
+
+		namespace string
+	)
+
+	BeforeEach(func() {
+		// Initialize fake clients
+		bucketClientset = bucketclientfake.NewSimpleClientset()
+		clientset = fake.NewSimpleClientset()
+
+		// Initialize ProvisionerServer with the fake BucketClientset
+		provisioner = &driver.ProvisionerServer{
+			Provisioner:     "test-provisioner",
+			Clientset:       clientset,
+			BucketClientset: bucketClientset,
+		}
+		mockIAMClient = &mock.MockIAMClient{}
+
+		bucketName = "test-bucket"
+		userName = "test-user"
+		secretName = "my-storage-secret"
+		namespace = "test-namespace"
+
+		// Create a fake Bucket object with appropriate parameters
+		_, err := bucketClientset.ObjectstorageV1alpha1().Buckets().Create(context.TODO(), &bucketv1alpha1.Bucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bucketName,
+			},
+			Spec: bucketv1alpha1.BucketSpec{
+				Parameters: map[string]string{
+					"objectStorageSecretName":      secretName,
+					"objectStorageSecretNamespace": namespace,
+				},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).To(BeNil())
+
+		// Create the request
+		request = &cosiapi.DriverRevokeBucketAccessRequest{
+			BucketId:  bucketName,
+			AccountId: userName,
+		}
+		originalInitializeClient = driver.InitializeClient
+
+		driver.InitializeClient = func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error) {
+			// Validate parameters
+			Expect(parameters["objectStorageSecretName"]).To(Equal(secretName))
+			Expect(parameters["objectStorageSecretNamespace"]).To(Equal(namespace))
+
+			if service == "IAM" {
+				return &iamclient.IAMClient{IAMService: mockIAMClient}, &util.StorageClientParameters{
+					Endpoint:        "https://test-endpoint",
+					AccessKeyID:     "test-access-key",
+					SecretAccessKey: "test-secret-key",
+				}, nil
+			}
+			return nil, nil, errors.New("unsupported service")
+		}
+	})
+
+	AfterEach(func() {
+		mockIAMClient = nil
+		bucketClientset = nil
+		clientset = nil
+		provisioner = nil
+		driver.InitializeClient = originalInitializeClient
+	})
+
+	It("should successfully revoke bucket access when bucket exists and parameters are valid", func(ctx SpecContext) {
+		resp, err := provisioner.DriverRevokeBucketAccess(ctx, request)
+
+		Expect(err).To(BeNil())
+		Expect(resp).NotTo(BeNil())
+		Expect(resp).To(BeAssignableToTypeOf(&cosiapi.DriverRevokeBucketAccessResponse{}))
+	})
+
+	It("should return error if the bucket does not exist", func(ctx SpecContext) {
+		err := bucketClientset.ObjectstorageV1alpha1().Buckets().Delete(context.TODO(), bucketName, metav1.DeleteOptions{})
+		Expect(err).To(BeNil())
+
+		resp, err := provisioner.DriverRevokeBucketAccess(ctx, request)
+
+		Expect(resp).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(err.Error()).To(ContainSubstring("failed to get bucket object from kubernetes"))
+	})
+
+	It("should return error if IAM client initialization fails", func(ctx SpecContext) {
+		driver.InitializeClient = func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error) {
+			return nil, nil, fmt.Errorf("mock IAM client initialization error")
+		}
+
+		resp, err := provisioner.DriverRevokeBucketAccess(ctx, request)
+
+		Expect(resp).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(err.Error()).To(ContainSubstring("failed to initialize object storage provider IAM client"))
+	})
+
+	It("should fail if unable to delete user", func(ctx SpecContext) {
+		mockIAMClient.GetUserFunc = func(ctx context.Context, input *iam.GetUserInput, opts ...func(*iam.Options)) (*iam.GetUserOutput, error) {
+			return nil, &smithy.OperationError{
+				Err: errors.New("AccessDenied: Access Denied"),
+			}
+		}
+
+		resp, err := provisioner.DriverRevokeBucketAccess(ctx, request)
+		Expect(resp).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(err.Error()).To(ContainSubstring("failed to revoke bucket access"))
+	})
+
+	It("should fail if unable to the right client", func(ctx SpecContext) {
+		driver.InitializeClient = func(ctx context.Context, clientset kubernetes.Interface, parameters map[string]string, service string) (interface{}, *util.StorageClientParameters, error) {
+			return &s3client.S3Client{S3Service: &mock.MockS3Client{}}, &util.StorageClientParameters{
+				Endpoint:        "https://test-endpoint",
+				AccessKeyID:     "test-access-key",
+				SecretAccessKey: "test-secret-key",
+			}, nil
+		}
+
+		resp, err := provisioner.DriverRevokeBucketAccess(ctx, request)
+		Expect(resp).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Internal))
+		Expect(err.Error()).To(ContainSubstring("unsupported client type for IAM operations"))
 	})
 })

--- a/pkg/driver/provisioner_server_impl_test.go
+++ b/pkg/driver/provisioner_server_impl_test.go
@@ -252,7 +252,6 @@ var _ = Describe("ProvisionerServer Unimplemented Methods", Ordered, func() {
 		provisioner *driver.ProvisionerServer
 		clientset   *fake.Clientset
 		bucketName  string
-		accountID   string
 	)
 
 	BeforeEach(func() {
@@ -262,7 +261,6 @@ var _ = Describe("ProvisionerServer Unimplemented Methods", Ordered, func() {
 			Clientset:   clientset,
 		}
 		bucketName = "test-bucket"
-		accountID = "test-account-id"
 	})
 
 	It("DriverDeleteBucket should return Unimplemented error", func(ctx SpecContext) {

--- a/pkg/mock/mock_iam.go
+++ b/pkg/mock/mock_iam.go
@@ -11,9 +11,14 @@ import (
 // MockIAMClient simulates the behavior of an IAM client for testing purposes.
 // It embeds iamclient.IAMClient to ensure compatibility with the interface or struct.
 type MockIAMClient struct {
-	CreateUserFunc      func(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error)
-	PutUserPolicyFunc   func(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error)
-	CreateAccessKeyFunc func(ctx context.Context, input *iam.CreateAccessKeyInput, opts ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error)
+	CreateUserFunc       func(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error)
+	PutUserPolicyFunc    func(ctx context.Context, input *iam.PutUserPolicyInput, opts ...func(*iam.Options)) (*iam.PutUserPolicyOutput, error)
+	CreateAccessKeyFunc  func(ctx context.Context, input *iam.CreateAccessKeyInput, opts ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error)
+	GetUserFunc          func(ctx context.Context, input *iam.GetUserInput, opts ...func(*iam.Options)) (*iam.GetUserOutput, error)
+	DeleteUserPolicyFunc func(ctx context.Context, input *iam.DeleteUserPolicyInput, opts ...func(*iam.Options)) (*iam.DeleteUserPolicyOutput, error)
+	ListAccessKeysFunc   func(ctx context.Context, input *iam.ListAccessKeysInput, opts ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error)
+	DeleteAccessKeyFunc  func(ctx context.Context, input *iam.DeleteAccessKeyInput, opts ...func(*iam.Options)) (*iam.DeleteAccessKeyOutput, error)
+	DeleteUserFunc       func(ctx context.Context, input *iam.DeleteUserInput, opts ...func(*iam.Options)) (*iam.DeleteUserOutput, error)
 }
 
 // CreateUser creates a mock IAM user with default behavior or custom logic.
@@ -48,4 +53,53 @@ func (m *MockIAMClient) CreateAccessKey(ctx context.Context, input *iam.CreateAc
 			SecretAccessKey: aws.String("mock-secret-access-key"),
 		},
 	}, nil
+}
+
+// GetUser retrieves a mock IAM user.
+func (m *MockIAMClient) GetUser(ctx context.Context, input *iam.GetUserInput, opts ...func(*iam.Options)) (*iam.GetUserOutput, error) {
+	if m.GetUserFunc != nil {
+		return m.GetUserFunc(ctx, input, opts...)
+	}
+	return &iam.GetUserOutput{
+		User: &types.User{
+			UserName: input.UserName,
+			UserId:   aws.String("mock-user-id"),
+		},
+	}, nil
+}
+
+// DeleteUserPolicy deletes a mock inline policy for the user.
+func (m *MockIAMClient) DeleteUserPolicy(ctx context.Context, input *iam.DeleteUserPolicyInput, opts ...func(*iam.Options)) (*iam.DeleteUserPolicyOutput, error) {
+	if m.DeleteUserPolicyFunc != nil {
+		return m.DeleteUserPolicyFunc(ctx, input, opts...)
+	}
+	return &iam.DeleteUserPolicyOutput{}, nil
+}
+
+// ListAccessKeys retrieves mock access keys for the user.
+func (m *MockIAMClient) ListAccessKeys(ctx context.Context, input *iam.ListAccessKeysInput, opts ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error) {
+	if m.ListAccessKeysFunc != nil {
+		return m.ListAccessKeysFunc(ctx, input, opts...)
+	}
+	return &iam.ListAccessKeysOutput{
+		AccessKeyMetadata: []types.AccessKeyMetadata{
+			{AccessKeyId: aws.String("mock-access-key-id")},
+		},
+	}, nil
+}
+
+// DeleteAccessKey deletes a mock access key for the user.
+func (m *MockIAMClient) DeleteAccessKey(ctx context.Context, input *iam.DeleteAccessKeyInput, opts ...func(*iam.Options)) (*iam.DeleteAccessKeyOutput, error) {
+	if m.DeleteAccessKeyFunc != nil {
+		return m.DeleteAccessKeyFunc(ctx, input, opts...)
+	}
+	return &iam.DeleteAccessKeyOutput{}, nil
+}
+
+// DeleteUser deletes a mock IAM user.
+func (m *MockIAMClient) DeleteUser(ctx context.Context, input *iam.DeleteUserInput, opts ...func(*iam.Options)) (*iam.DeleteUserOutput, error) {
+	if m.DeleteUserFunc != nil {
+		return m.DeleteUserFunc(ctx, input, opts...)
+	}
+	return &iam.DeleteUserOutput{}, nil
 }


### PR DESCRIPTION
### Summary

This PR implements the DriverRevokeBucketAccess API, enhances the IAM client, and adds comprehensive tests, including unit and end-to-end coverage.

### Key Changes
1. COSI-40: Remove Prefix from Inline Policies
  - Inline policy names now match bucket names, simplifying access control.
2. COSI-40: API Implementation
  - Fetches bucket parameters for IAM client configuration.
  - Adds IAM methods to delete users, inline policies, and keys.
3. COSI-40: Add Unit Tests
- Updated IAM mock and added unit tests for IAM client new methods and RevokeBucketAccess.
4. COSI-52: Add E2E Test
- Validates end-to-end flow for revoking bucket access by checking if the IAM user was deleted.