### PR TITLE
Add Prometheus metrics for S3 and IAM requests

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,10 +19,44 @@ var (
 		},
 		[]string{"method", "status"},
 	)
+	S3RequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "s3_requests_total",
+			Help: "Total number of S3 requests, categorized by method and status.",
+		},
+		[]string{"method", "status"},
+	)
+	S3RequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "s3_request_duration_seconds",
+			Help:    "Duration of S3 requests in seconds, categorized by method and status.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method", "status"},
+	)
+	IAMRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "iam_requests_total",
+			Help: "Total number of IAM requests, categorized by method and status.",
+		},
+		[]string{"method", "status"},
+	)
+	IAMRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "iam_request_duration_seconds",
+			Help:    "Duration of IAM requests in seconds, categorized by method and status.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method", "status"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(RequestsTotal)
+	prometheus.MustRegister(S3RequestsTotal)
+	prometheus.MustRegister(S3RequestDuration)
+	prometheus.MustRegister(IAMRequestsTotal)
+	prometheus.MustRegister(IAMRequestDuration)
 }
 
 func StartMetricsServer(addr string) (*http.Server, error) {


### PR DESCRIPTION
- Introduced `S3RequestsTotal` and `S3RequestDuration` to track total number of S3 requests and their duration, categorized by method and status.
- Added `IAMRequestsTotal` and `IAMRequestDuration` for IAM request metrics, categorized similarly.
- Registered all metrics, including `RequestsTotal`, with Prometheus.
- Enhances observability of S3 and IAM operations, allowing detailed monitoring and performance analysis.

Issue: COSI-19