### PR TITLE
COSI-61 disable trace export if endpoint not specified(default) and test new default behaviour in e2e feature tests (stdout export remains same)

### DIFF
--- a/.github/scripts/setup_cosi_resources.sh
+++ b/.github/scripts/setup_cosi_resources.sh
@@ -45,10 +45,6 @@ log_and_run docker build -t ghcr.io/scality/cosi-driver:latest .
 log_and_run echo "Loading COSI driver image into KIND cluster..."
 log_and_run kind load docker-image ghcr.io/scality/cosi-driver:latest --name object-storage-cluster
 
-# Log trace output to std out for e2e tests
-sed -i 's/# - "--driver-otel-stdout=false"/- "--driver-otel-stdout=true"/' kustomize/base/deployment.yaml
-cat kustomize/base/deployment.yaml
-
 # Step 5: Run COSI driver
 log_and_run echo "Applying COSI driver manifests..."
 if ! kubectl apply -k .; then

--- a/helm/scality-cosi-driver/values.yaml
+++ b/helm/scality-cosi-driver/values.yaml
@@ -34,11 +34,22 @@ metrics:
   path: "/metrics"
 
 traces:
-  # endpoint for trace collector to send traces to
-  otel_endpoint: "http://localhost:4318"
-  # prints traces to stdout if true and does not send to collector
+  # Configure tracing for the application.
+
+  # If both `otel_stdout` and `otel_endpoint` are set, `otel_stdout` takes precedence.
+  # Set `otel_stdout: false` and `otel_endpoint: ""` to disable tracing entirely.
+
+  # The endpoint of the trace collector to which traces will be sent.
+  # Use an empty string ("") to disable endpoint-based trace collection.
+  # Use the format "http://<host>:<port>/v1/trace" to specify the collector endpoint.
+  otel_endpoint: ""
+
+  # Enable stdout tracing by setting this to true. When enabled, traces will be printed
+  # to the console instead of being sent to the collector endpoint.
   otel_stdout: false
-  # Trace span service name
+
+  # The name of the service to appear in trace spans, used for identification
+  # in observability tools.
   otel_service_name: "cosi.scality.com"
 
 resources:


### PR DESCRIPTION
1. OpenTelemetry Configuration Updates
	•	Default Endpoint: Modified the default OpenTelemetry endpoint to be an empty string ("") to avoid unintended errors if no trace collector endpoint is provided.
	•	Tracing Logic: Updated logic to disable tracing when both otel_stdout and otel_endpoint are unset.
	•	Service Name: Added driverOtelServiceName to the initialization process log for better trace span identification.

2. Helm Chart Enhancements
	•	Improved Comments: Enhanced the values.yaml file with detailed comments explaining the usage of otel_stdout and otel_endpoint.
	•	Default Values: Updated the default values to ensure trace collection is explicitly configured by the user, avoiding unintentional trace exports.

3. Script Adjustments for E2E Testing
	•	Disabled tracing in e2e feature tests to verify the system’s default behavior without tracing enabled.