### PR TITLE
COSI-77: Use namespace defined by CNCF in COSI controller

### DIFF
--- a/.github/scripts/capture_k8s_logs.sh
+++ b/.github/scripts/capture_k8s_logs.sh
@@ -6,7 +6,7 @@ mkdir -p logs/kind_cluster_logs
 LOG_FILE_PATH=".github/e2e_tests/artifacts/logs/kind_cluster_logs"
 mkdir -p "$(dirname "$LOG_FILE_PATH")"  # Ensure the log directory exists
 # Define namespaces to capture logs from
-namespaces=("default" "scality-object-storage")
+namespaces=("default" "container-object-storage-system")
 
 # Loop through specified namespaces, pods, and containers
 for namespace in "${namespaces[@]}"; do

--- a/.github/scripts/cleanup_cosi_resources.sh
+++ b/.github/scripts/cleanup_cosi_resources.sh
@@ -19,11 +19,11 @@ log_and_run() {
 
 log_and_run echo "Removing COSI driver manifests and namespace..."
 log_and_run kubectl delete -k . || { echo "COSI driver manifests not found." | tee -a "$LOG_FILE"; }
-log_and_run kubectl delete namespace scality-object-storage || { echo "Namespace scality-object-storage not found." | tee -a "$LOG_FILE"; }
+log_and_run kubectl delete namespace container-object-storage-system || { echo "Namespace container-object-storage-system not found." | tee -a "$LOG_FILE"; }
 
 log_and_run echo "Verifying namespace deletion..."
-if kubectl get namespace scality-object-storage &>/dev/null; then
-  echo "Warning: Namespace scality-object-storage was not deleted." | tee -a "$LOG_FILE"
+if kubectl get namespace container-object-storage-system &>/dev/null; then
+  echo "Warning: Namespace container-object-storage-system was not deleted." | tee -a "$LOG_FILE"
   exit 1
 fi
 

--- a/.github/scripts/e2e_tests_brownfield_use_case.sh
+++ b/.github/scripts/e2e_tests_brownfield_use_case.sh
@@ -9,7 +9,7 @@ SECRET_NAME="brownfield-bucket-secret"
 IAM_ENDPOINT="http://$HOST_IP:8600"
 S3_ENDPOINT="http://$HOST_IP:8000"
 BUCKET_NAME="brownfield-bucket"
-NAMESPACE="scality-object-storage"
+NAMESPACE="container-object-storage-system"
 REGION="us-west-1"
 
 # Error handling function

--- a/.github/scripts/e2e_tests_metrics.sh
+++ b/.github/scripts/e2e_tests_metrics.sh
@@ -4,7 +4,7 @@ set -e
 LOG_FILE=".github/e2e_tests/artifacts/logs/e2e_tests/metrics_service.log"
 mkdir -p "$(dirname "$LOG_FILE")"
 
-NAMESPACE="scality-object-storage"
+NAMESPACE="container-object-storage-system"
 SERVICE="scality-cosi-driver-metrics"
 LOCAL_PORT=8080
 TARGET_PORT=8080

--- a/.github/scripts/setup_cosi_resources.sh
+++ b/.github/scripts/setup_cosi_resources.sh
@@ -54,10 +54,10 @@ fi
 
 # Step 6: Verify COSI driver Pod Status
 log_and_run echo "Verifying COSI driver Pod status..."
-if ! kubectl wait --namespace scality-object-storage --for=condition=ready pod --selector=app.kubernetes.io/name=scality-cosi-driver --timeout=30s; then
+if ! kubectl wait --namespace container-object-storage-system --for=condition=ready pod --selector=app.kubernetes.io/name=scality-cosi-driver --timeout=30s; then
   echo "Error: COSI driver Pod did not reach ready state." | tee -a "$LOG_FILE"
   exit 1
 fi
-log_and_run kubectl get pods -n scality-object-storage
+log_and_run kubectl get pods -n container-object-storage-system
 
 log_and_run echo "COSI setup completed successfully."

--- a/.github/scripts/verify_helm_install.sh
+++ b/.github/scripts/verify_helm_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-NAMESPACE="scality-object-storage"
+NAMESPACE="container-object-storage-system"
 
 echo "Verifying Helm installation..."
 

--- a/.github/workflows/helm-validation.yml
+++ b/.github/workflows/helm-validation.yml
@@ -60,14 +60,14 @@ jobs:
     - name: Install Scality COSI Helm Chart
       run: |
         helm install scality-cosi-driver ./helm/scality-cosi-driver \
-          --namespace scality-object-storage \
+          --namespace container-object-storage-system \
           --create-namespace \
           --set image.tag=latest \
           --set traces.otel_stdout=true
 
-    - name: Print all resources in scality-object-storage namespace
+    - name: Print all resources in container-object-storage-system namespace
       run: |
-        kubectl get all -n scality-object-storage
+        kubectl get all -n container-object-storage-system
 
     - name: Verify Helm Installation
       run: |
@@ -94,6 +94,6 @@ jobs:
 
     - name: Cleanup Helm Release and Namespace
       run: |
-        helm uninstall scality-cosi-driver -n scality-object-storage
-        kubectl delete namespace scality-object-storage
+        helm uninstall scality-cosi-driver -n container-object-storage-system
+        kubectl delete namespace container-object-storage-system
       if: always()

--- a/cosi-examples/brownfield/bucket.yaml
+++ b/cosi-examples/brownfield/bucket.yaml
@@ -2,7 +2,7 @@ apiVersion: objectstorage.k8s.io/v1alpha1
 kind: Bucket
 metadata:
   name: brownfield-bucket # should be same as bucket name
-  namespace: scality-object-storage
+  namespace: container-object-storage-system
 spec:
   bucketClaim: {}
   bucketClassName: brownfield-bucket-class

--- a/cosi-examples/brownfield/bucketaccess.yaml
+++ b/cosi-examples/brownfield/bucketaccess.yaml
@@ -2,7 +2,7 @@ apiVersion: objectstorage.k8s.io/v1alpha1
 kind: BucketAccess
 metadata:
   name: brownfield-bucket-access
-  namespace: scality-object-storage
+  namespace: container-object-storage-system
 spec:
   bucketAccessClassName: brownfield-bucket-access-class
   bucketClaimName: brownfield-bucket-claim

--- a/cosi-examples/brownfield/bucketaccessclass.yaml
+++ b/cosi-examples/brownfield/bucketaccessclass.yaml
@@ -2,7 +2,7 @@ kind: BucketAccessClass
 apiVersion: objectstorage.k8s.io/v1alpha1
 metadata:
   name: brownfield-bucket-access-class
-  namespace: scality-object-storage
+  namespace: container-object-storage-system
 driverName: cosi.scality.com
 authenticationType: KEY
 parameters:

--- a/cosi-examples/brownfield/bucketclaim.yaml
+++ b/cosi-examples/brownfield/bucketclaim.yaml
@@ -2,7 +2,7 @@ apiVersion: objectstorage.k8s.io/v1alpha1
 kind: BucketClaim
 metadata:
   name: brownfield-bucket-claim
-  namespace: scality-object-storage
+  namespace: container-object-storage-system
 spec:
   bucketClassName: brownfield-bucket-class
   existingBucketName: brownfield-bucket # name of Bucket object

--- a/cosi-examples/brownfield/bucketclass.yaml
+++ b/cosi-examples/brownfield/bucketclass.yaml
@@ -2,7 +2,7 @@ apiVersion: objectstorage.k8s.io/v1alpha1
 kind: BucketClass
 metadata:
   name: brownfield-bucket-class
-  namespace: scality-object-storage
+  namespace: container-object-storage-system
 driverName: cosi.scality.com
 deletionPolicy: Delete
 parameters:

--- a/docs/development/remote-debugging-golang-on-kubernetes.md
+++ b/docs/development/remote-debugging-golang-on-kubernetes.md
@@ -44,7 +44,7 @@ kubectl apply -k kustomize/overlays/debug
 Wait until the pod is ready to ensure the deployment succeeded:
 
 ```bash
-kubectl wait --namespace scality-object-storage --for=condition=ready pod --selector=app.kubernetes.io/name=scality-cosi-driver --timeout=120s
+kubectl wait --namespace container-object-storage-system --for=condition=ready pod --selector=app.kubernetes.io/name=scality-cosi-driver --timeout=120s
 ```
 
 ---
@@ -54,13 +54,13 @@ kubectl wait --namespace scality-object-storage --for=condition=ready pod --sele
 Identify the pod name for the COSI driver:
 
 ```bash
-kubectl get pods -n scality-object-storage
+kubectl get pods -n container-object-storage-system
 ```
 
 Forward port `2345` from the Kubernetes pod to your local machine to connect VS Code to the Delve debugger:
 
 ```bash
-kubectl port-forward -n scality-object-storage pod/<pod-name> 2345:2345
+kubectl port-forward -n container-object-storage-system pod/<pod-name> 2345:2345
 ```
 
 Replace `<pod-name>` with the actual name of the pod.

--- a/docs/installation/install-helm.md
+++ b/docs/installation/install-helm.md
@@ -36,7 +36,7 @@ This guide provides step-by-step instructions for installing the Scality COSI Dr
 ```bash
     git clone https://github.com/scality/cosi-driver.git
     cd cosi-driver
-    helm install scality-cosi-driver ./helm/scality-cosi-driver --namespace scality-object-storage --create-namespace --set image.tag=0.1.0
+    helm install scality-cosi-driver ./helm/scality-cosi-driver --namespace container-object-storage-system --create-namespace --set image.tag=0.1.0
 ```
 
 ### Package locally and install
@@ -45,7 +45,7 @@ This guide provides step-by-step instructions for installing the Scality COSI Dr
     git clone https://github.com/scality/cosi-driver.git
     cd cosi-driver
     helm package ./helm/scality-cosi-driver --version 0.1.0
-    helm install scality-cosi-driver ./scality-cosi-driver-0.1.0.tgz --namespace scality-object-storage --create-namespace --set image.tag=0.1.0
+    helm install scality-cosi-driver ./scality-cosi-driver-0.1.0.tgz --namespace container-object-storage-system --create-namespace --set image.tag=0.1.0
 ```
 
 ### Install from OCI Registry with Helm

--- a/helm/scality-cosi-driver/templates/rbac.yaml
+++ b/helm/scality-cosi-driver/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: scality-object-storage-provisioner-role
+  name: scality-cosi-driver-provisioner-role
 rules:
   - apiGroups: ["objectstorage.k8s.io"]
     resources: ["buckets", "bucketaccesses", "bucketclaims", "bucketaccessclasses"]
@@ -17,12 +17,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: scality-object-storage-provisioner-role-binding
+  name: scality-cosi-driver-provisioner-role-binding
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}
     namespace: {{ .Values.namespace }}
 roleRef:
   kind: ClusterRole
-  name: scality-object-storage-provisioner-role
+  name: scality-cosi-driver-provisioner-role
   apiGroup: rbac.authorization.k8s.io

--- a/helm/scality-cosi-driver/values.yaml
+++ b/helm/scality-cosi-driver/values.yaml
@@ -18,7 +18,7 @@ logLevels:
   sidecar: "2"
 
 
-namespace: scality-object-storage
+namespace: container-object-storage-system
 fullnameOverride: scality-cosi-driver
 
 

--- a/helm/scality-cosi-driver/values.yaml
+++ b/helm/scality-cosi-driver/values.yaml
@@ -23,7 +23,7 @@ fullnameOverride: scality-cosi-driver
 
 
 serviceAccount:
-  name: scality-object-storage-provisioner
+  name: scality-cosi-driver-provisioner
   create: true
 
 metrics:

--- a/kustomize/base/deployment.yaml
+++ b/kustomize/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/version: main
         app.kubernetes.io/managed-by: kustomize
     spec:
-      serviceAccountName: scality-object-storage-provisioner
+      serviceAccountName: scality-cosi-driver-provisioner
       containers:
         - name: scality-cosi-driver
           image: ghcr.io/scality/cosi-driver:latest

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: scality-object-storage
+namespace: container-object-storage-system
 
 resources:
   - namespace.yaml

--- a/kustomize/base/namespace.yaml
+++ b/kustomize/base/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: scality-object-storage
+  name: scality-cosi-driver

--- a/kustomize/base/rbac.yaml
+++ b/kustomize/base/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: scality-object-storage-provisioner-role
+  name: scality-cosi-driver-provisioner-role
 rules:
   - apiGroups: ["objectstorage.k8s.io"]
     resources: ["buckets", "bucketaccesses", "bucketclaims", "bucketaccessclasses", "buckets/status", "bucketaccesses/status", "bucketclaims/status", "bucketaccessclasses/status"]
@@ -20,12 +20,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: scality-object-storage-provisioner-role-binding
+  name: scality-cosi-driver-provisioner-role-binding
 subjects:
   - kind: ServiceAccount
-    name: scality-object-storage-provisioner
+    name: scality-cosi-driver-provisioner
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: scality-object-storage-provisioner-role
+  name: scality-cosi-driver-provisioner-role
   apiGroup: rbac.authorization.k8s.io

--- a/kustomize/base/serviceaccount.yaml
+++ b/kustomize/base/serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: scality-object-storage-provisioner
+  name: scality-cosi-driver-provisioner
   namespace: default

--- a/kustomize/overlays/debug/deployment.yaml
+++ b/kustomize/overlays/debug/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/version: main
         app.kubernetes.io/managed-by: kustomize
     spec:
-      serviceAccountName: scality-object-storage-provisioner
+      serviceAccountName: scality-cosi-driver-provisioner
       containers:
         - name: scality-cosi-driver
           image: ghcr.io/scality/cosi-driver-delve:latest

--- a/kustomize/overlays/dev/kustomization.yaml
+++ b/kustomize/overlays/dev/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: scality-object-storage
+namespace: container-object-storage-system
 
 configMapGenerator:
 - name: scality-cosi-driver-properties


### PR DESCRIPTION
Motivation:

The CNCF has introduced a fixed namespace for COSI (container-object-storage-system). This standard ensures consistency across deployments, especially for brownfield use cases where the COSI driver (sidecar) must interact with the Kubernetes Events API within the same namespace as the COSI controller.

Context:

Originally, the COSI controller did not specify a namespace, leading us to create a custom namespace (scality-object-storage) for the COSI driver. For brownfield scenarios, deploying the driver in the same namespace as the controller is mandatory. Initially, we planned to guide users to manage this manually. However, with the fixed namespace now defined by CNCF, we are updating our deployment to adhere to this standard.

Changes:
	1.	Updated the COSI driver namespace from scality-object-storage to container-object-storage-system.
	2.	Updated resource naming conventions to use the prefix scality-cosi-driver instead of scality-object-storage.

These changes ensure compliance with CNCF guidelines, improve ease of deployment, and enhance compatibility for brownfield use cases.