### PR TITLE
COSI-82 Pin version of objectstorage sidecar

### DIFF
--- a/helm/scality-cosi-driver/templates/deployment.yaml
+++ b/helm/scality-cosi-driver/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         - name: objectstorage-provisioner-sidecar
-          image: gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:latest
+          image: gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20241219-v0.1.0-60-g6a5a12c
           imagePullPolicy: IfNotPresent
           args:
             - "--v={{ .Values.logLevels.sidecar }}"

--- a/kustomize/base/deployment.yaml
+++ b/kustomize/base/deployment.yaml
@@ -40,7 +40,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         - name: objectstorage-provisioner-sidecar
-          image: gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:latest
+          image: gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20241219-v0.1.0-60-g6a5a12c
           imagePullPolicy: IfNotPresent
           args:
             - "--v=$(OBJECTSTORAGE_PROVISIONER_SIDECAR_LOG_LEVEL)"


### PR DESCRIPTION
Will not necessarily close COSI-82 with this, but since the `latest` sidecar tag does not work with cosi anymore and @davidtencer found a working version, let's pin it.

