### PR TITLE
COSI-81 future proof docs with next releases

### DIFF
--- a/docs/installation/install-helm.md
+++ b/docs/installation/install-helm.md
@@ -24,27 +24,43 @@ Its recommended to deploy COSI controller first which creates the `container-obj
 kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface
 ```
 
+
+### Install from OCI Registry with Helm
+
+To automatically install the latest release of cosi-driver:
+
+```bash
+    helm install scality-cosi-driver oci://ghcr.io/scality/cosi-driver/helm-charts/scality-cosi-driver --namespace container-object-storage-system --create-namespace
+```
+
+Or find a desired version listed in the [releases] and
+specify it when installing:
+
+```bash
+    helm install scality-cosi-driver oci://ghcr.io/scality/cosi-driver/helm-charts/scality-cosi-driver --namespace container-object-storage-system --create-namespace --version <tag>
+```
+
 ### Install locally without helm package
+
+Find the latest or a desired version available under [releases].
 
 ```bash
     git clone https://github.com/scality/cosi-driver.git
     cd cosi-driver
-    helm install scality-cosi-driver ./helm/scality-cosi-driver --namespace container-object-storage-system --create-namespace --set image.tag=1.0.0
+    # replace <tag> with the latest version
+    helm install scality-cosi-driver ./helm/scality-cosi-driver --namespace container-object-storage-system --create-namespace --set image.tag=<tag>
 ```
 
 ### Package locally and install
 
+Find the latest or a desired version available under [releases].
+
 ```bash
     git clone https://github.com/scality/cosi-driver.git
     cd cosi-driver
-    helm package ./helm/scality-cosi-driver --version 1.0.0
-    helm install scality-cosi-driver ./scality-cosi-driver-1.0.0.tgz --namespace container-object-storage-system --create-namespace --set image.tag=1.0.0
-```
-
-### Install from OCI Registry with Helm
-
-```bash
-    helm install scality-cosi-driver oci://ghcr.io/scality/cosi-driver/helm-charts/scality-cosi-driver --namespace container-object-storage-system --create-namespace --set image.tag=1.0.0
+    # replace <tag> with the latest version
+    helm package ./helm/scality-cosi-driver --version <tag> --app-version <tag>
+    helm install scality-cosi-driver ./scality-cosi-driver-<tag>.tgz --namespace container-object-storage-system --create-namespace
 ```
 
 ---
@@ -112,3 +128,5 @@ When a new release of the Scality COSI Driver is published, it includes:
 
 - A Docker image pushed to `ghcr.io/scality/cosi-driver:<tag>`
 - A Helm chart available in the OCI registry `ghcr.io/scality/cosi-driver/helm-charts/scality-cosi-driver`
+
+[releases]: https://github.com/scality/cosi-driver/releases

--- a/helm/scality-cosi-driver/Chart.yaml
+++ b/helm/scality-cosi-driver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: scality-cosi-driver
 description: A Helm chart for deploying the Scality COSI Driver
-version: 1.0.1
-appVersion: "1.0.0"
+version: 1.0.2
+appVersion: "1.0.2"

--- a/helm/scality-cosi-driver/templates/deployment.yaml
+++ b/helm/scality-cosi-driver/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
         - name: scality-cosi-driver
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "--driver-prefix=cosi"

--- a/helm/scality-cosi-driver/values.yaml
+++ b/helm/scality-cosi-driver/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/scality/cosi-driver
-  tag: 1.0.0
+  tag:
   pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
Trying to make the doc future proof and ensure we don't have to keep maintaining it for each release. It does "hurt" the user experience in some cases, but I believe it was improved for proper releases when installing via oci which may lead us to make that the default installation method.

### What's happening?

On the `release.yaml` workflow we already package the helm chart with the flags `--version` and `--app-version`, which make the `.Chart.AppVersion` var available for use in the helm template, with the right value.

So when installing proper releases of the chart, we don't have to specify the version anymore as it will be properly set when packaged, and this command will automatically pick the latest version and install it:

```shell
helm install scality-cosi-driver \
  oci://ghcr.io/scality/cosi-driver/helm-charts/scality-cosi-driver \
  --namespace container-object-storage-system \
  --create-namespace
```

But we always have the choice to specify one as needed, tried to update the doc as well accordingly. 