### PR TITLE
COSI-88: Switch deprecated reviewers to CODEOWNERS for dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @scality/object

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
       time: "07:00"
       timezone: "Europe/Paris"
     open-pull-requests-limit: 10
-    reviewers:
-      - "scality/object"
     commit-message:
       prefix: "gomod"
       include: "scope"
@@ -40,8 +38,6 @@ updates:
     schedule:
       interval: "weekly"
       time: "08:00"
-    reviewers:
-      - "scality/object"
     commit-message:
       prefix: "github-actions"
       include: "scope"


### PR DESCRIPTION
Issue: COSI-88

Switch deprecated reviewers to CODEOWNERS for dependabot
[Reference](https://github.com/scality/devdocs/discussions/718)
