### PR TITLE
COSI-98: Pin COSI install docs and CI to v1alpha1 (v0.2.2)

### DIFF
--- a/.github/scripts/cleanup_cosi_resources.sh
+++ b/.github/scripts/cleanup_cosi_resources.sh
@@ -63,7 +63,7 @@ log_and_run echo "Deleting s3-secret-for-cosi secret..."
 log_and_run kubectl delete secret s3-secret-for-cosi --namespace=default || { echo "Secret s3-secret-for-cosi not found." | tee -a "$LOG_FILE"; }
 
 log_and_run echo "Deleting COSI CRD..."
-log_and_run kubectl delete -k github.com/kubernetes-sigs/container-object-storage-interface || { echo "COSI API CRDs or controller not found." | tee -a "$LOG_FILE"; }
+log_and_run kubectl delete -k github.com/kubernetes-sigs/container-object-storage-interface?ref=v0.2.2 || { echo "COSI API CRDs or controller not found." | tee -a "$LOG_FILE"; }
 
 log_and_run echo "Verifying COSI CRDs deletion..."
 if kubectl get crd | grep 'container-object-storage-interface' &>/dev/null; then

--- a/.github/scripts/setup_cosi_resources.sh
+++ b/.github/scripts/setup_cosi_resources.sh
@@ -26,7 +26,7 @@ log_and_run() {
 
 # Step 1: Install COSI CRDs
 log_and_run echo "Installing COSI CRD..."
-log_and_run kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface
+log_and_run kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface?ref=v0.2.2
 log_and_run kubectl get pods --namespace container-object-storage-system
 
 # Step 2: Verify COSI Controller Pod Status

--- a/.github/workflows/build-and-unit-tests.yml
+++ b/.github/workflows/build-and-unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Install Ginkgo CLI
       - name: Install Ginkgo CLI
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@latest
+        run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.2
 
       - name: Install dependencies
         run: go mod tidy

--- a/.github/workflows/helm-validation.yml
+++ b/.github/workflows/helm-validation.yml
@@ -77,7 +77,7 @@ jobs:
         set -e -o pipefail
         (
           echo "=== Setup COSI Controller, CRDs and Driver ==="
-          kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface
+          kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface?ref=v0.2.2
           make container
           kind load docker-image ghcr.io/scality/cosi-driver:latest --name helm-test-cluster
         ) &

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Use [Quickstart](#quickstart-guide) or follow the [installation guide](docs/inst
 To quickly deploy and test the Scality COSI Driver:
 
 1. Ensure your Kubernetes cluster is properly configured, and [Helm v3+ is installed](https://helm.sh/docs/intro/install/). The COSI specification was introduced in Kubernetes 1.25. We recommend using [one of the latest supported Kubernetes versions](https://kubernetes.io/releases/).
-2. Create namespace `container-object-storage-system` and install the COSI controller deployment and COSI CRDs:
+2. Create namespace `container-object-storage-system` and install the COSI controller deployment and COSI CRDs. The Scality COSI Driver supports only COSI **v1alpha1** — the command below pins upstream to tag `v0.2.2` (the last v1alpha1 release). Do not install from upstream `main`, which now ships v1alpha2 and is incompatible with this driver.
 
    ```bash
-   kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface
+   kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface?ref=v0.2.2
    ```
 
 3. Deploy the driver: Namespace `container-object-storage-system` will be created in step 2.

--- a/docs/installation/install-helm.md
+++ b/docs/installation/install-helm.md
@@ -21,8 +21,10 @@ Its recommended to deploy COSI controller first which creates the `container-obj
 
 ### Deploy COSI controller and related CRDs
 
+The Scality COSI Driver supports only COSI **v1alpha1**. The command below pins the upstream controller and CRDs to tag `v0.2.2` (the last v1alpha1 release) — do not install from upstream `main`, which now ships v1alpha2 and is incompatible with this driver.
+
 ```bash
-kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface
+kubectl create -k github.com/kubernetes-sigs/container-object-storage-interface?ref=v0.2.2
 ```
 
 


### PR DESCRIPTION
## Intent: why this change exists?

Users following the install docs were getting a broken cluster. The unpinned `kubectl create -k <upstream-url>` started tracking upstream `main` after it moved to v1alpha2 CRDs, while this driver only speaks v1alpha1.

## System impact: what's affected, including downstream?

Every install surface that hits the upstream kustomize URL: `README.md`, `docs/installation/install-helm.md`, and the three CI touchpoints (`helm-validation.yml`, `setup_cosi_resources.sh`, `cleanup_cosi_resources.sh`). Nothing downstream of the driver changes; the artifact itself is untouched.

## Preserved behavior: what explicitly doesn't change?

No runtime or code changes. Driver still builds against `sigs.k8s.io/container-object-storage-interface-api v0.1.0`, Helm chart and container image are identical, and the CRDs installed on a cluster are still v1alpha1, just fetched from a pinned ref instead of a rolling one.

## Intended change: what's different after this PR?

Pin the install URL to `?ref=v0.2.2` (last v1alpha1 release, Dec 2025) everywhere it appears, plus a one-sentence "v1alpha1 only, don't install from upstream main" note in the docs. Second pin in the same PR that may look unrelated: `go install ginkgo@latest` becomes `@v2.22.2` in the unit-test workflow, because `@latest` floated to v2.28.1 which requires Go 1.24 and the workflow pins Go 1.23.2. Same rolling-ref bug class, different tool.

## Verification: how do we know this worked, or how would we know if it didn't?

Verified locally on a fresh kind cluster: install succeeds, all 5 CRDs report `v1alpha1(served=true, storage=true)`, and the sample `cosi-examples/greenfield/*.yaml` manifests pass `kubectl apply --dry-run=server`. Green CI on this branch (`Kustomize Validation`, `Helm Validation`, `Build & Unit Tests`) is the gating signal. Failure modes to watch: a 404 on the pinned ref means the tag is wrong, and CRD admission errors on v1alpha1 manifests would mean the pin resolved to the wrong API shape.
